### PR TITLE
Fix unknown command output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,8 +91,7 @@ async fn start_repl() {
 
 
 fn unknown_command(cmd: &str) -> ! {
-    eprintln!("Unknown command: {}
-Usage: raft [run <filename>|repl|--version]", cmd);
+    eprintln!("Unknown command: {}\nUsage: raft [run <filename>|repl|--version]", cmd);
     process::exit(1);
 }
 


### PR DESCRIPTION
## Summary
- fix formatting of the `unknown_command` error message

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_683f42b405d08328b063e1d2d45eaa51