### PR TITLE
Initialize logging early

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ cargo run -- repl
 cargo run -- --version
 ```
 
+Logging is controlled via the `RUST_LOG` environment variable. Enable info-level
+output like so:
+
+```
+RUST_LOG=info cargo run -- run script.raft
+```
+
 Example `.raft` file:
 ```
 actor Main {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ use raft::vm::VM;
 
 #[tokio::main]
 async fn main() {
+    // Initialize env_logger so log output respects RUST_LOG
+    env_logger::init();
+
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {


### PR DESCRIPTION
## Summary
- call `env_logger::init` early in the CLI entry point
- mention `RUST_LOG` usage in the README

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_683f42b75a688328b78fffc1b3f15aaa