### PR TITLE
Fix unused variable warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub async fn run(source: &str) -> Result<(), String> {
         }
     };
 
-    let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+    let (mut vm, _tx) = VM::new(bytecode, None, Backend::default());
     match vm.run().await {
         Ok(_) => {
             log::info!("Program executed successfully");

--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -47,10 +47,10 @@ impl ExecutionContext {
         let opcode = self.bytecode[self.ip];
         log::info!("Executing opcode: {:?}", opcode);
 
-        let stack = &mut self.stack;
-        let call_stack = &mut self.call_stack;
+        let _stack = &mut self.stack;
+        let _call_stack = &mut self.call_stack;
         let ip = self.ip;
-        let locals = &mut self.locals;
+        let _locals = &mut self.locals;
 
         // Clone the opcode to avoid immutable borrow issues.
         let opcode = self.bytecode[ip].clone();

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -79,7 +79,7 @@ impl OpCode {
     pub async fn execute(
         &self,
         execution: &mut ExecutionContext,        
-        heap: &mut Heap,
+        _heap: &mut Heap,
         mailbox: &mut Receiver<Value>,        
     ) -> Result<(), String> {        
         match self {

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -14,8 +14,8 @@ pub struct VM {
     heap: Heap,
     bytecode: Vec<OpCode>,
     pub mailbox: Receiver<Value>,
-    supervisor: Option<Sender<usize>>,
-    backend: Backend,
+    _supervisor: Option<Sender<usize>>,
+    _backend: Backend,
 }
 
 impl VM {
@@ -32,8 +32,8 @@ impl VM {
                 heap: Heap::new(),
                 bytecode,
                 mailbox: rx,
-                supervisor,
-                backend,
+                _supervisor: supervisor,
+                _backend: backend,
             },
             tx,
         )


### PR DESCRIPTION
## Summary
- rename unused tx variable in lib.rs
- prefix unused variables in ExecutionContext::step
- mark heap parameter in OpCode::execute as unused
- mark unused fields in VM struct
- run cargo check

## Testing
- `cargo check`
- `cargo test` *(fails: vm::tests::test_basic_arithmetic, vm::vm::tests::test_basic_arithmetic, vm::vm::tests::test_jump_and_call_modify_ip, vm::vm::tests::test_sequential_ip_increment)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff82b24c8328b593ed80b1b5cffb