### PR TITLE
Simplify step()

### DIFF
--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -44,34 +44,13 @@ impl ExecutionContext {
             return Err("Execution out of bounds".to_string());
         }
 
-        let opcode = self.bytecode[self.ip];
+        let opcode = self.bytecode[self.ip].clone();
         log::info!("Executing opcode: {:?}", opcode);
 
-        let stack = &mut self.stack;
-        let call_stack = &mut self.call_stack;
-        let ip = self.ip;
-        let locals = &mut self.locals;
-
-        // Clone the opcode to avoid immutable borrow issues.
-        let opcode = self.bytecode[ip].clone();
-        // advance instruction pointer unless opcode modified it
+        // advance instruction pointer before execution unless the opcode modifies it
         self.ip += 1;
 
-        opcode.execute(self, heap, mailbox).await?;
-
-        if self.ip == ip {
-            self.ip += 1;
-        }
-
-        let prev_ip = self.ip;
-        let result = opcode.execute(self, heap, mailbox).await;
-
-        if self.ip == prev_ip {
-            self.ip += 1;
-        }
-
-        result
-
+        opcode.execute(self, heap, mailbox).await
     }
 
     pub fn ip(&self) -> usize {

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -90,7 +90,6 @@ mod tests {
         let (mut vm, _tx) = VM::new(code, None, Backend::default());
         vm.run().await.unwrap();
 
-
         match vm.execution.stack.pop() {
             Some(Value::Integer(8)) => {}
             other => panic!("Expected Some(Integer(8)), got {:?}", other),
@@ -144,7 +143,6 @@ mod tests {
 
         ctx.step(&mut heap, &mut rx).await.unwrap();
         assert_eq!(ctx.ip, 2);
-        assert_eq!(ctx.call_stack, vec![0]);
-
+        assert_eq!(ctx.call_stack, vec![1]);
     }
 }


### PR DESCRIPTION
## Summary
- remove unused locals and double execution
- pre-increment IP and execute once
- update call stack test for new behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841ff81feac83288d5346b8aa68ad39