### PR TITLE
Refactor opcode fetch in VM execution

### DIFF
--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -45,18 +45,9 @@ impl ExecutionContext {
         }
 
         let opcode = self.bytecode[self.ip].clone();
-        log::info!("Executing opcode: {:?}", opcode);
-
-        let _stack = &mut self.stack;
-        let _call_stack = &mut self.call_stack;
-        let ip = self.ip;
-        let _locals = &mut self.locals;
-
-        // Clone the opcode to avoid immutable borrow issues.
-        let opcode = self.bytecode[ip].clone();
         // advance instruction pointer unless opcode modified it
         self.ip += 1;
-
+        log::info!("Executing opcode: {:?}", opcode);
         opcode.execute(self, heap, mailbox).await
     }
 


### PR DESCRIPTION
## Summary
- Simplify VM execution step by fetching opcode once and advancing the IP before executing
- Remove unused variables previously used to appease borrow checker

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6893c4a34e0883288ce6037321bc6eb4