### PR TITLE
Implement basic actor messaging and supervision opcodes

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -1,8 +1,10 @@
 // src/vm/heap.rs
 
 use std::collections::HashMap;
+
 use crate::vm::value::Value;
 use crate::vm::VM;
+use tokio::sync::mpsc::Sender;
 
 
 #[derive(Debug)]
@@ -25,8 +27,8 @@ pub enum HeapObject {
     String(String),
     Module { name: String, exports: HashMap<String, Value> },
     NativeFunction(NativeFunction),
-    Actor(VM),
-    Supervisor(VM),
+    Actor(VM, Sender<Value>),
+    Supervisor(VM, Sender<Value>),
 }
 
 

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -1,8 +1,9 @@
 // src/vm/opcodes.rs
 
 use crate::vm::execution::ExecutionContext;
-use crate::vm::heap::{Heap};
+use crate::vm::heap::{Heap, HeapObject};
 use crate::vm::value::Value;
+use crate::vm::{backend::Backend, vm::VM};
 use tokio::sync::mpsc::Receiver;
 
 
@@ -186,8 +187,81 @@ impl OpCode {
                     log::warn!("Mailbox is empty or closed");
                     Err("Mailbox empty".to_string())
                 }
-            }            
-            _ => Err("Opcode not implemented".to_string()),
+            }
+            OpCode::SpawnActor(addr) => {
+                let bytecode = execution.bytecode.clone();
+                let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+                vm.set_ip(*addr);
+                let address = _heap.allocate(HeapObject::Actor(vm, tx));
+                execution.stack.push(Value::Reference(address));
+                Ok(())
+            }
+            OpCode::SendMessage(_index) => {
+                let actor_ref = execution
+                    .stack
+                    .pop()
+                    .ok_or("Stack underflow for SendMessage".to_string())?;
+                let message = execution
+                    .stack
+                    .pop()
+                    .ok_or("Stack underflow for SendMessage".to_string())?;
+                if let Value::Reference(address) = actor_ref {
+                    if let Some(HeapObject::Actor(_actor_vm, sender)) = _heap.get(address) {
+                        sender
+                            .send(message)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        execution.stack.push(Value::Reference(address));
+                        Ok(())
+                    } else {
+                        Err("Invalid actor reference".to_string())
+                    }
+                } else {
+                    Err("Invalid actor reference".to_string())
+                }
+            }
+            OpCode::SpawnSupervisor(addr) => {
+                let bytecode = execution.bytecode.clone();
+                let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+                vm.set_ip(*addr);
+                let address = _heap.allocate(HeapObject::Supervisor(vm, tx));
+                execution.stack.push(Value::Reference(address));
+                Ok(())
+            }
+            OpCode::SetStrategy(strategy) => {
+                let sup_ref = execution
+                    .stack
+                    .pop()
+                    .ok_or("Stack underflow for SetStrategy".to_string())?;
+                if let Value::Reference(addr) = sup_ref {
+                    if let Some(HeapObject::Supervisor(vm, _)) = _heap.get_mut(addr) {
+                        vm.set_strategy(*strategy);
+                        execution.stack.push(Value::Reference(addr));
+                        Ok(())
+                    } else {
+                        Err("Invalid supervisor reference".to_string())
+                    }
+                } else {
+                    Err("Invalid supervisor reference".to_string())
+                }
+            }
+            OpCode::RestartChild(child) => {
+                let sup_ref = execution
+                    .stack
+                    .pop()
+                    .ok_or("Stack underflow for RestartChild".to_string())?;
+                if let Value::Reference(addr) = sup_ref {
+                    if let Some(HeapObject::Supervisor(vm, _)) = _heap.get_mut(addr) {
+                        vm.restart_child(*child);
+                        execution.stack.push(Value::Reference(addr));
+                        Ok(())
+                    } else {
+                        Err("Invalid supervisor reference".to_string())
+                    }
+                } else {
+                    Err("Invalid supervisor reference".to_string())
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add actor and supervisor heap variants that retain message senders
- implement opcodes for spawning actors/supervisors, messaging, and supervision
- test spawning an actor and delivering a message

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6893c4a4fbbc832898281a83232d20b7