### PR TITLE
Remove unused Frame struct

### DIFF
--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -10,12 +10,6 @@ use crate::vm::value::Value;
 use tokio::sync::mpsc::Receiver;
 
 #[derive(Debug)]
-pub struct Frame {
-    pub return_address: usize,
-    pub locals: HashMap<usize, Value>,
-}
-
-#[derive(Debug)]
 pub struct ExecutionContext {
     pub stack: Vec<Value>,
     pub locals: HashMap<usize, Value>,


### PR DESCRIPTION
## Summary
- delete unused `Frame` struct to simplify execution context

## Testing
- `cargo test` *(fails: could not compile `raft` due to undeclared type `HeapObject` and missing `VM::set_ip` method)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c2901b483288b80104f785a9985