### PR TITLE
Remove Peek opcode and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ raft-vm
 ### Opcodes
 Raft uses a custom bytecode instruction set that mirrors fundamental operations:
 - **Arithmetic**: `Add`, `Sub`, `Mul`, `Div`, `Mod`, `Neg`, `Exp`
-- **Stack**: `PushConst`, `Pop`, `Dup`, `Swap`, `Peek`
+- **Stack**: `PushConst`, `Pop`, `Dup`, `Swap`
 - **Control Flow**: `Jump`, `JumpIfFalse`, `Call`, `Return`
 - **Actor Management**: `SpawnActor`, `SendMessage`, `ReceiveMessage`
 - **Supervision**: `SpawnSupervisor`, `SetStrategy`, `RestartChild`

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -47,7 +47,6 @@ pub enum OpCode {
     Pop,
     Dup,
     Swap,
-    Peek,
 
     // Arithmetic
     Add,
@@ -125,14 +124,6 @@ impl OpCode {
                     Ok(())
                 } else {
                     Err("Stack underflow for StoreVar".into())
-                }
-            }
-            OpCode::Peek => {
-                if let Some(v) = execution.stack.last() {
-                    execution.stack.push(*v);
-                    Ok(())
-                } else {
-                    Err("Stack underflow for Peek".into())
                 }
             }
             OpCode::LoadVar(index) => {


### PR DESCRIPTION
## Summary
- drop `Peek` opcode and rely on `Dup`
- document updated stack instructions

## Testing
- `cargo test` *(fails: use of undeclared type `HeapObject` in opcodes.rs)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c29ee088328b09a550bda3052f0