### PR TITLE
Add reference counting to heap objects for garbage collection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,19 @@ use raft::vm::VM;
 use std::io::Write;
 use tokio::io::{self, AsyncBufReadExt};
 
+#[derive(Parser)]
+#[command(name = "raft")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Run { filename: String },
+    Repl,
+    Version,
+}
 
 #[tokio::main]
 async fn main() {
@@ -93,7 +106,6 @@ async fn start_repl() {
         }
     }
 }
-
 
 fn unknown_command(cmd: &str) -> ! {
     eprintln!(

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -44,6 +44,10 @@ impl VM {
         self.execution.stack.pop()
     }
 
+    pub fn set_ip(&mut self, ip: usize) {
+        self.execution.ip = ip;
+    }
+
     pub async fn run(&mut self) -> Result<(), VmError> {
         if self.bytecode.is_empty() {
             log::warn!("Attempted to run VM with empty bytecode");
@@ -172,7 +176,7 @@ mod tests {
 
         // Retrieve actor from heap and run it to process message
         let actor_entry = vm.heap.get_mut(actor_addr).expect("actor not found");
-        if let HeapObject::Actor(actor_vm, _sender) = actor_entry {
+        if let HeapObject::Actor(actor_vm, _sender, _) = actor_entry {
             actor_vm.run().await.unwrap();
             assert_eq!(actor_vm.pop_stack(), Some(Value::Integer(42)));
         } else {


### PR DESCRIPTION
## Summary
- track reference counts for all `HeapObject` variants
- collect garbage by removing heap entries with zero references
- define missing CLI structures so binary builds in tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f4c274a7c83289054ef9c199cb151