### PR TITLE
Remove SendMessage index and update actor messaging

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -5,6 +5,7 @@ use crate::vm::execution::ExecutionContext;
 use crate::vm::heap::Heap;
 use crate::vm::value::Value;
 use crate::vm::{backend::Backend, vm::VM};
+use crate::vm::HeapObject;
 use tokio::sync::mpsc::Receiver;
 
 fn unary_op<F>(stack: &mut Vec<Value>, f: F) -> Result<(), VmError>
@@ -66,7 +67,7 @@ pub enum OpCode {
 
     // Actors
     SpawnActor(usize),
-    SendMessage(usize),
+    SendMessage,
     ReceiveMessage,
 
     // Supervisor
@@ -192,8 +193,6 @@ impl OpCode {
                 }
             }
 
-            _ => Err("Opcode not implemented".into()),
-
             OpCode::SpawnActor(addr) => {
                 let bytecode = execution.bytecode.clone();
                 let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
@@ -202,15 +201,15 @@ impl OpCode {
                 execution.stack.push(Value::Reference(address));
                 Ok(())
             }
-            OpCode::SendMessage(_index) => {
+            OpCode::SendMessage => {
                 let actor_ref = execution
                     .stack
                     .pop()
-                    .ok_or("Stack underflow for SendMessage".to_string())?;
+                    .ok_or_else(|| VmError::from("Stack underflow for SendMessage"))?;
                 let message = execution
                     .stack
                     .pop()
-                    .ok_or("Stack underflow for SendMessage".to_string())?;
+                    .ok_or_else(|| VmError::from("Stack underflow for SendMessage"))?;
                 if let Value::Reference(address) = actor_ref {
                     if let Some(HeapObject::Actor(_actor_vm, sender)) = _heap.get(address) {
                         sender
@@ -220,10 +219,10 @@ impl OpCode {
                         execution.stack.push(Value::Reference(address));
                         Ok(())
                     } else {
-                        Err("Invalid actor reference".to_string())
+                        Err("Invalid actor reference".into())
                     }
                 } else {
-                    Err("Invalid actor reference".to_string())
+                    Err("Invalid actor reference".into())
                 }
             }
             OpCode::SpawnSupervisor(addr) => {
@@ -238,37 +237,36 @@ impl OpCode {
                 let sup_ref = execution
                     .stack
                     .pop()
-                    .ok_or("Stack underflow for SetStrategy".to_string())?;
+                    .ok_or_else(|| VmError::from("Stack underflow for SetStrategy"))?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _)) = _heap.get_mut(addr) {
                         vm.set_strategy(*strategy);
                         execution.stack.push(Value::Reference(addr));
                         Ok(())
                     } else {
-                        Err("Invalid supervisor reference".to_string())
+                        Err("Invalid supervisor reference".into())
                     }
                 } else {
-                    Err("Invalid supervisor reference".to_string())
+                    Err("Invalid supervisor reference".into())
                 }
             }
             OpCode::RestartChild(child) => {
                 let sup_ref = execution
                     .stack
                     .pop()
-                    .ok_or("Stack underflow for RestartChild".to_string())?;
+                    .ok_or_else(|| VmError::from("Stack underflow for RestartChild"))?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _)) = _heap.get_mut(addr) {
                         vm.restart_child(*child);
                         execution.stack.push(Value::Reference(addr));
                         Ok(())
                     } else {
-                        Err("Invalid supervisor reference".to_string())
+                        Err("Invalid supervisor reference".into())
                     }
                 } else {
-                    Err("Invalid supervisor reference".to_string())
+                    Err("Invalid supervisor reference".into())
                 }
             }
-
         }
     }
 }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -44,6 +44,10 @@ impl VM {
         self.execution.stack.pop()
     }
 
+    pub fn set_ip(&mut self, ip: usize) {
+        self.execution.ip = ip;
+    }
+
     pub async fn run(&mut self) -> Result<(), VmError> {
         if self.bytecode.is_empty() {
             log::warn!("Attempted to run VM with empty bytecode");
@@ -155,7 +159,7 @@ mod tests {
         let code = vec![
             OpCode::PushConst(Value::Integer(42)), // message
             OpCode::SpawnActor(4),                 // spawn actor starting at 4
-            OpCode::SendMessage(0),                // send message
+            OpCode::SendMessage,                // send message
             OpCode::Jump(5),                       // skip child code
             // Child actor code starts here (index 4)
             OpCode::ReceiveMessage,


### PR DESCRIPTION
## Summary
- import `HeapObject` in opcodes
- remove unused parameter from `SendMessage` opcode and update execution logic
- adjust VM tests to match new opcode and add `set_ip` helper

## Testing
- `cargo test --lib`
- `cargo test` *(fails: use of undeclared type `Cli`)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c253a9c8328a763cf7d0b3f36d2