### PR TITLE
Fix duplicate HeapObject import

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -5,7 +5,6 @@ use crate::vm::execution::ExecutionContext;
 use crate::vm::heap::{Heap, HeapObject};
 use crate::vm::value::Value;
 use crate::vm::{backend::Backend, vm::VM};
-use crate::vm::HeapObject;
 use tokio::sync::mpsc::Receiver;
 
 fn unary_op<F>(stack: &mut Vec<Value>, f: F) -> Result<(), VmError>


### PR DESCRIPTION
## Summary
- Remove duplicate HeapObject import in opcodes module to resolve compile error

## Testing
- `cargo test --all --locked`


------
https://chatgpt.com/codex/tasks/task_e_689fb00e3a4883289136dbf5e9600bd9