### PR TITLE
Remove unreachable opcode match arm and unused CLI helpers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,15 +109,4 @@ async fn start_repl() {
     }
 }
 
-fn unknown_command(cmd: &str) -> ! {
-    eprintln!(
-        "Unknown command: {}\nUsage: raft [run <filename>|repl|--version]",
-        cmd
-    );
-    process::exit(1);
-}
-
-fn print_usage_and_exit() -> ! {
-    eprintln!("Usage: raft [run <filename>|repl|--version]");
-    process::exit(1);
-}
+// Removed unused utility functions that produced dead-code warnings.

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -257,8 +257,6 @@ impl OpCode {
                 }
             }
 
-            _ => Err("Opcode not implemented".into()),
-
         }
     }
 }


### PR DESCRIPTION
## Summary
- eliminate unreachable `_` arm in opcode execution
- drop unused `unknown_command` and `print_usage_and_exit` helpers

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689fb1b0353c8328a99c4bdf3cdbdbc6