### PR TITLE
chore: remove serde dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ thiserror = "1.0"
 log = "0.4"
 env_logger = "0.10"
 clap = { version = "4.4", features = ["derive"] }  # command-line parsing
-serde = { version = "1.0", features = ["derive"] }  # serialization
 
 [profile.dev]
 debug = true


### PR DESCRIPTION
## Summary
- remove unused serde dependency from Cargo manifest

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68a3542522a08328819ea1bc859fb5e0