### PR TITLE
Support float and boolean literals in compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,15 @@ Example `.raft` file:
 ```
 # push 1 and 2 on the stack and add them
 1 2 +
+
+# push a boolean and a float
+true 3.14
 ```
 
-The current compiler only tokenizes whitespace separated integers and
-the `+` operator. Running the above file will leave `3` on the VM's
-stack.
+The current compiler tokenizes whitespace separated integers, floats
+(tokens containing a decimal point), booleans (`true`/`false`) and basic
+arithmetic like `+`. Running the above file will leave `3`, `true`, and
+`3.14` on the VM's stack.
 
 ---
 

--- a/examples/literals.raft
+++ b/examples/literals.raft
@@ -1,0 +1,3 @@
+# demonstrates boolean and float literals
+true false
+3.14 2.0 +

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -11,7 +11,14 @@ impl Compiler {
 
         let mut tokens = source.split_whitespace();
         while let Some(token) = tokens.next() {
-            if let Ok(num) = token.parse::<i32>() {
+            if token == "true" || token == "false" {
+                bytecode.push(OpCode::PushConst(Value::Boolean(token == "true")));
+            } else if token.contains('.') {
+                let num = token
+                    .parse::<f64>()
+                    .map_err(|_| format!("Invalid float: {}", token))?;
+                bytecode.push(OpCode::PushConst(Value::Float(num)));
+            } else if let Ok(num) = token.parse::<i32>() {
                 bytecode.push(OpCode::PushConst(Value::Integer(num)));
             } else {
                 match token {

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -31,3 +31,22 @@ fn compile_control_flow_tokens() {
     assert!(matches!(bytecode[3], OpCode::Jump(8)));
     assert!(matches!(bytecode[4], OpCode::Return));
 }
+
+#[test]
+fn compile_float_tokens() {
+    let source = "3.14 2.0 +";
+    let bytecode = Compiler::compile(source).unwrap();
+    assert_eq!(bytecode.len(), 3);
+    assert!(matches!(bytecode[0], OpCode::PushConst(Value::Float(f)) if (f - 3.14).abs() < f64::EPSILON));
+    assert!(matches!(bytecode[1], OpCode::PushConst(Value::Float(f)) if (f - 2.0).abs() < f64::EPSILON));
+    assert!(matches!(bytecode[2], OpCode::Add));
+}
+
+#[test]
+fn compile_boolean_tokens() {
+    let source = "true false";
+    let bytecode = Compiler::compile(source).unwrap();
+    assert_eq!(bytecode.len(), 2);
+    assert!(matches!(bytecode[0], OpCode::PushConst(Value::Boolean(true))));
+    assert!(matches!(bytecode[1], OpCode::PushConst(Value::Boolean(false))));
+}


### PR DESCRIPTION
## Summary
- parse `true`/`false` and numeric tokens with decimals in the compiler
- document and exemplify the new boolean and float literals
- test float and boolean token compilation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a35424e060832894525fa0d62a4fcd