### PR TITLE
Remove unused backend abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,20 @@ stack.
 ## Architecture
 
 ### Components
-- **VM (Virtual Machine)**: Manages bytecode execution, stack, heap, and message 
+- **VM (Virtual Machine)**: Manages bytecode execution, stack, heap, and message
                             passing.
-- **Execution Context**: Maintains the state of the current program, including 
+- **Execution Context**: Maintains the state of the current program, including
                          the instruction pointer and call stack.
-- **Heap**: Allocates and manages dynamic memory for arrays, strings, and 
+- **Heap**: Allocates and manages dynamic memory for arrays, strings, and
             modules.
-- **Opcodes**: Define the core instruction set for the VM, such as arithmetic, 
+- **Opcodes**: Define the core instruction set for the VM, such as arithmetic,
                stack manipulation, and control flow.
-
-
+ 
+### Platform Integration
+The previous codebase included a placeholder `Backend` abstraction intended for
+platform-specific hooks. The VM no longer depends on this layer and operates
+solely through its runtime and message-passing interfaces. Future integrations
+can be added by extending opcodes or runtime components as needed.
 
 ### Opcodes
 Raft uses a custom bytecode instruction set that mirrors fundamental operations:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use compiler::Compiler;
 pub use runtime::Actor;
 pub use vm::VM;
 
-use crate::vm::{Backend, VmError};
+use crate::vm::VmError;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -17,6 +17,6 @@ pub async fn run(source: &str) -> Result<(), VmError> {
     let bytecode = Compiler::compile(source)
         .map_err(|e| VmError::from(format!("Compilation Error: {}", e)))?;
 
-    let (mut vm, _tx) = VM::new(bytecode, None, Backend::default());
+    let (mut vm, _tx) = VM::new(bytecode, None);
     vm.run().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use std::fs;
 use std::process;
 
 use raft::compiler::Compiler;
-use raft::vm::backend::Backend;
 use raft::vm::value::Value;
 use raft::vm::VM;
 
@@ -63,7 +62,7 @@ async fn handle_run(filename: &str) {
     match fs::read_to_string(filename) {
         Ok(source) => {
             let bytecode = Compiler::compile(&source).unwrap();
-            let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+            let (mut vm, tx) = VM::new(bytecode, None);
 
             // Simulate sending messages to the VM
             tokio::spawn(async move {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc::Sender;
 
 use crate::vm::error::VmError;
 use crate::vm::value::Value;
-use crate::vm::{Backend, OpCode, VM};
+use crate::vm::{OpCode, VM};
 
 /// A lightweight wrapper around a `VM` that exposes a mailbox
 /// for message passing.
@@ -15,8 +15,8 @@ pub struct Actor {
 
 impl Actor {
     /// Create a new actor from bytecode.
-    pub fn new(bytecode: Vec<OpCode>, backend: Backend) -> Self {
-        let (vm, tx) = VM::new(bytecode, None, backend);
+    pub fn new(bytecode: Vec<OpCode>) -> Self {
+        let (vm, tx) = VM::new(bytecode, None);
         Actor { vm, sender: tx }
     }
 

--- a/src/vm/backend.rs
+++ b/src/vm/backend.rs
@@ -1,4 +1,0 @@
-// src/vm/backend.rs
-
-#[derive(Default,Debug)]
-pub struct Backend;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,6 +1,5 @@
 // src/vm/mod.rs
 
-pub mod backend;
 pub mod error;
 pub mod execution;
 pub mod heap;
@@ -8,7 +7,6 @@ pub mod opcodes;
 pub mod value;
 pub mod vm;
 
-pub use crate::vm::backend::Backend;
 pub use crate::vm::error::VmError;
 pub use crate::vm::execution::ExecutionContext;
 pub use crate::vm::heap::{Heap, HeapObject};
@@ -20,8 +18,6 @@ pub use crate::vm::vm::VM;
 mod tests {
     use super::*;
 
-    use crate::vm::backend::Backend;
-
     #[tokio::test]
     async fn test_basic_arithmetic() {
         let code = vec![
@@ -30,7 +26,7 @@ mod tests {
             OpCode::Add,
         ];
 
-        let (mut vm, _tx) = VM::new(code, None, Backend::default());
+        let (mut vm, _tx) = VM::new(code, None);
         vm.run().await.unwrap();
 
         assert_eq!(vm.stack().last().cloned(), Some(Value::Integer(8)));

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -4,7 +4,7 @@ use crate::vm::error::VmError;
 use crate::vm::execution::ExecutionContext;
 use crate::vm::heap::{Heap, HeapObject};
 use crate::vm::value::Value;
-use crate::vm::{backend::Backend, vm::VM};
+use crate::vm::vm::VM;
 use tokio::sync::mpsc::Receiver;
 
 fn unary_op<F>(stack: &mut Vec<Value>, f: F) -> Result<(), VmError>
@@ -185,7 +185,7 @@ impl OpCode {
 
             OpCode::SpawnActor(addr) => {
                 let bytecode = execution.bytecode.clone();
-                let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+                let (mut vm, tx) = VM::new(bytecode, None);
                 vm.set_ip(*addr);
                 let address = _heap.allocate(HeapObject::Actor(vm, tx, 1));
                 execution.stack.push(Value::Reference(address));
@@ -215,7 +215,7 @@ impl OpCode {
             }
             OpCode::SpawnSupervisor(addr) => {
                 let bytecode = execution.bytecode.clone();
-                let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+                let (mut vm, tx) = VM::new(bytecode, None);
                 vm.set_ip(*addr);
                 let address = _heap.allocate(HeapObject::Supervisor(vm, tx, 1));
                 execution.stack.push(Value::Reference(address));

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -1,6 +1,5 @@
 // src/vm/vm.rs
 
-use crate::vm::backend::Backend;
 use crate::vm::error::VmError;
 use crate::vm::execution::ExecutionContext;
 use crate::vm::heap::Heap;
@@ -15,14 +14,12 @@ pub struct VM {
     heap: Heap,
     pub mailbox: Receiver<Value>,
     _supervisor: Option<Sender<usize>>,
-    _backend: Backend,
 }
 
 impl VM {
     pub fn new(
         bytecode: Vec<OpCode>,
         supervisor: Option<Sender<usize>>,
-        backend: Backend,
     ) -> (Self, Sender<Value>) {
         let (tx, rx) = mpsc::channel(100);
         log::info!("Initializing VM with {} opcodes", bytecode.len());
@@ -32,7 +29,6 @@ impl VM {
                 heap: Heap::new(),
                 mailbox: rx,
                 _supervisor: supervisor,
-                _backend: backend,
             },
             tx,
         )
@@ -79,7 +75,6 @@ impl VM {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vm::backend::Backend;
     use crate::vm::value::Value;
 
     #[tokio::test]
@@ -90,7 +85,7 @@ mod tests {
             OpCode::Add,
         ];
 
-        let (mut vm, _tx) = VM::new(code, None, Backend::default());
+        let (mut vm, _tx) = VM::new(code, None);
         vm.run().await.unwrap();
 
         match vm.execution.stack.pop() {
@@ -163,7 +158,7 @@ mod tests {
             OpCode::ReceiveMessage,
         ];
 
-        let (mut vm, _tx) = VM::new(code, None, Backend::default());
+        let (mut vm, _tx) = VM::new(code, None);
         vm.run().await.unwrap();
 
         // Actor reference should remain on stack after sending


### PR DESCRIPTION
## Summary
- remove the unused `Backend` module and simplify `VM::new`
- update runtime and opcodes to spawn VMs without a backend
- document that the VM currently operates without a backend layer

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68a3541fdcfc832881cdd700c41b1d4c