### PR TITLE
Refactor VM error handling with explicit variants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Runs a Raft program from source code
 pub async fn run(source: &str) -> Result<(), VmError> {
-    let bytecode = Compiler::compile(source)
-        .map_err(|e| VmError::from(format!("Compilation Error: {}", e)))?;
+    let bytecode = Compiler::compile(source).map_err(VmError::CompilationError)?;
 
     let (mut vm, _tx) = VM::new(bytecode, None, Backend::default());
     vm.run().await

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -30,7 +30,7 @@ impl Actor {
         self.sender
             .send(msg)
             .await
-            .map_err(|e| VmError::from(e.to_string()))
+            .map_err(|e| VmError::ChannelSend(e.to_string()))
     }
 
     /// Execute the actor until its VM halts.

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -1,22 +1,26 @@
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Error, Clone)]
 pub enum VmError {
-    Message(String),
+    #[error("Stack underflow")]
+    StackUnderflow,
+    #[error("Type mismatch in {0}")]
+    TypeMismatch(&'static str),
+    #[error("Division by zero")]
+    DivisionByZero,
+    #[error("Execution out of bounds")]
+    ExecutionOutOfBounds,
+    #[error("No bytecode to execute")]
+    NoBytecode,
+    #[error("Variable at index {0} not found")]
+    VariableNotFound(usize),
+    #[error("Invalid reference")]
+    InvalidReference,
+    #[error("Mailbox empty")]
+    MailboxEmpty,
+    #[error("Channel send error: {0}")]
+    ChannelSend(String),
+    #[error("Compilation error: {0}")]
+    CompilationError(String),
 }
 
-impl<T: Into<String>> From<T> for VmError {
-    fn from(value: T) -> Self {
-        VmError::Message(value.into())
-    }
-}
-
-impl fmt::Display for VmError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            VmError::Message(msg) => write!(f, "{}", msg),
-        }
-    }
-}
-
-impl std::error::Error for VmError {}

--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -36,7 +36,7 @@ impl ExecutionContext {
     ) -> Result<(), VmError> {
         if self.ip >= self.bytecode.len() {
             log::error!("Instruction pointer out of bounds: {}", self.ip);
-            return Err("Execution out of bounds".into());
+            return Err(VmError::ExecutionOutOfBounds);
         }
 
         let opcode = self.bytecode[self.ip].clone();

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -17,7 +17,7 @@ where
         Ok(())
     } else {
         log::error!("Stack underflow during unary operation");
-        Err("Stack underflow for unary operation".into())
+        Err(VmError::StackUnderflow)
     }
 }
 
@@ -27,7 +27,7 @@ where
 {
     if stack.len() < 2 {
         log::error!("Stack underflow during binary operation");
-        return Err("Stack underflow for binary operation".into());
+        return Err(VmError::StackUnderflow);
     }
     let b = stack.pop().unwrap();
     let a = stack.pop().unwrap();
@@ -89,7 +89,7 @@ impl OpCode {
             OpCode::Neg => unary_op(&mut execution.stack, |a| match a {
                 Value::Integer(i) => Ok(Value::Integer(-i)),
                 Value::Float(f) => Ok(Value::Float(-f)),
-                _ => Err("Cannot negate non-numeric value".into()),
+                _ => Err(VmError::TypeMismatch("Neg")),
             }),
             OpCode::PushConst(v) => {
                 execution.stack.push(*v);
@@ -99,7 +99,7 @@ impl OpCode {
                 execution
                     .stack
                     .pop()
-                    .ok_or_else(|| VmError::from("Stack underflow"))?;
+                    .ok_or(VmError::StackUnderflow)?;
                 Ok(())
             }
             OpCode::Dup => {
@@ -107,12 +107,12 @@ impl OpCode {
                     execution.stack.push(v);
                     Ok(())
                 } else {
-                    Err("Stack underflow".into())
+                    Err(VmError::StackUnderflow)
                 }
             }
             OpCode::Swap => {
                 if execution.stack.len() < 2 {
-                    return Err("Stack underflow for Swap".into());
+                    return Err(VmError::StackUnderflow);
                 }
                 let len = execution.stack.len();
                 execution.stack.swap(len - 1, len - 2);
@@ -123,7 +123,7 @@ impl OpCode {
                     execution.locals.insert(*index, value);
                     Ok(())
                 } else {
-                    Err("Stack underflow for StoreVar".into())
+                    Err(VmError::StackUnderflow)
                 }
             }
             OpCode::LoadVar(index) => {
@@ -131,23 +131,23 @@ impl OpCode {
                     execution.stack.push(*value);
                     Ok(())
                 } else {
-                    Err(format!("Variable at index {} not found", index).into())
+                    Err(VmError::VariableNotFound(*index))
                 }
             }
             OpCode::Mod => binary_op(&mut execution.stack, |a, b| match (a, b) {
                 (Value::Integer(x), Value::Integer(y)) => {
                     if y == 0 {
-                        Err("Modulo by zero".into())
+                        Err(VmError::DivisionByZero)
                     } else {
                         Ok(Value::Integer(x % y))
                     }
                 }
-                _ => Err("Type mismatch for Mod".into()),
+                _ => Err(VmError::TypeMismatch("Mod")),
             }),
             OpCode::Exp => binary_op(&mut execution.stack, |a, b| match (a, b) {
                 (Value::Integer(x), Value::Integer(y)) => Ok(Value::Integer(x.pow(y as u32))),
                 (Value::Float(x), Value::Float(y)) => Ok(Value::Float(x.powf(y))),
-                _ => Err("Type mismatch for Exp".into()),
+                _ => Err(VmError::TypeMismatch("Exp")),
             }),
             OpCode::Jump(target) => {
                 execution.ip = *target;
@@ -169,7 +169,7 @@ impl OpCode {
                     execution.ip = return_addr;
                     Ok(())
                 } else {
-                    Err("Call stack underflow on Return".into())
+                    Err(VmError::StackUnderflow)
                 }
             }
             OpCode::ReceiveMessage => {
@@ -179,7 +179,7 @@ impl OpCode {
                     Ok(())
                 } else {
                     log::warn!("Mailbox is empty or closed");
-                    Err("Mailbox empty".into())
+                    Err(VmError::MailboxEmpty)
                 }
             }
 
@@ -195,21 +195,24 @@ impl OpCode {
                 let actor_ref = execution
                     .stack
                     .pop()
-                    .ok_or_else(|| VmError::from("Stack underflow for SendMessage"))?;
+                    .ok_or(VmError::StackUnderflow)?;
                 let message = execution
                     .stack
                     .pop()
-                    .ok_or_else(|| VmError::from("Stack underflow for SendMessage"))?;
+                    .ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(address) = actor_ref {
                     if let Some(HeapObject::Actor(_actor_vm, sender, _)) = _heap.get(address) {
-                        sender.send(message).await.map_err(|e| e.to_string())?;
+                        sender
+                            .send(message)
+                            .await
+                            .map_err(|e| VmError::ChannelSend(e.to_string()))?;
                         execution.stack.push(Value::Reference(address));
                         Ok(())
                     } else {
-                        Err("Invalid actor reference".to_string().into())
+                        Err(VmError::InvalidReference)
                     }
                 } else {
-                    Err("Invalid actor reference".to_string().into())
+                    Err(VmError::InvalidReference)
 
                 }
             }
@@ -225,17 +228,17 @@ impl OpCode {
                 let sup_ref = execution
                     .stack
                     .pop()
-                    .ok_or_else(|| VmError::from("Stack underflow for SetStrategy"))?;
+                    .ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _, _)) = _heap.get_mut(addr) {
                         vm.set_strategy(*strategy);
                         execution.stack.push(Value::Reference(addr));
                         Ok(())
                     } else {
-                        Err("Invalid supervisor reference".to_string().into())
+                        Err(VmError::InvalidReference)
                     }
                 } else {
-                    Err("Invalid supervisor reference".to_string().into())
+                    Err(VmError::InvalidReference)
 
                 }
             }
@@ -243,17 +246,17 @@ impl OpCode {
                 let sup_ref = execution
                     .stack
                     .pop()
-                    .ok_or_else(|| VmError::from("Stack underflow for RestartChild"))?;
+                    .ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _, _)) = _heap.get_mut(addr) {
                         vm.restart_child(*child);
                         execution.stack.push(Value::Reference(addr));
                         Ok(())
                     } else {
-                        Err("Invalid supervisor reference".to_string().into())
+                        Err(VmError::InvalidReference)
                     }
                 } else {
-                    Err("Invalid supervisor reference".to_string().into())
+                    Err(VmError::InvalidReference)
                 }
             }
 

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -17,7 +17,7 @@ impl Value {
         match (self, other) {
             (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a + b)),
             (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a + b)),
-            _ => Err("Type mismatch for Add".into()),
+            _ => Err(VmError::TypeMismatch("Add")),
         }
     }
 
@@ -25,7 +25,7 @@ impl Value {
         match (self, other) {
             (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a - b)),
             (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a - b)),
-            _ => Err("Type mismatch for Sub".into()),
+            _ => Err(VmError::TypeMismatch("Sub")),
         }
     }
 
@@ -33,7 +33,7 @@ impl Value {
         match (self, other) {
             (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a * b)),
             (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a * b)),
-            _ => Err("Type mismatch for Mul".into()),
+            _ => Err(VmError::TypeMismatch("Mul")),
         }
     }
 
@@ -42,7 +42,7 @@ impl Value {
             (Value::Integer(a), Value::Integer(b)) => {
                 if b == 0 {
                     log::error!("Division by zero: {}/{}", a, b);
-                    Err("Division by zero".into())
+                    Err(VmError::DivisionByZero)
                 } else {
                     Ok(Value::Integer(a / b))
                 }
@@ -50,14 +50,14 @@ impl Value {
             (Value::Float(a), Value::Float(b)) => {
                 if b == 0.0 {
                     log::error!("Division by zero: {}/{}", a, b);
-                    Err("Division by zero".into())
+                    Err(VmError::DivisionByZero)
                 } else {
                     Ok(Value::Float(a / b))
                 }
             }
             _ => {
                 log::error!("Div type mismatch: {:?} / {:?}", self, other);
-                Err("Type mismatch for Div".into())
+                Err(VmError::TypeMismatch("Div"))
             }
         }
     }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -49,7 +49,7 @@ impl VM {
     pub async fn run(&mut self) -> Result<(), VmError> {
         if self.execution.bytecode.is_empty() {
             log::warn!("Attempted to run VM with empty bytecode");
-            return Err("No bytecode to execute".into());
+            return Err(VmError::NoBytecode);
         }
 
         while self.execution.ip < self.execution.bytecode.len() {


### PR DESCRIPTION
## Summary
- Replace generic `VmError` with `thiserror`-based enum of concrete variants
- Update VM logic and runtime to construct specific error variants
- Adjust top-level runners to propagate new error types

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68a35425e4ec8328a46ebd521aea1c23