### PR TITLE
Remove backend parameter from VM construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,9 @@ arithmetic like `+`. Running the above file will leave `3`, `true`, and
                stack manipulation, and control flow.
  
 ### Platform Integration
-The previous codebase included a placeholder `Backend` abstraction intended for
-platform-specific hooks. The VM no longer depends on this layer and operates
-solely through its runtime and message-passing interfaces. Future integrations
-can be added by extending opcodes or runtime components as needed.
+The VM operates solely through its runtime and message-passing interfaces.
+Platform-specific hooks can be added by extending opcodes or runtime components
+as needed.
 
 ### Opcodes
 Raft uses a custom bytecode instruction set that mirrors fundamental operations:

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ async fn handle_run(filename: &str) {
                     process::exit(1);
                 }
             };
-            let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+            let (mut vm, tx) = VM::new(bytecode, None);
 
             // Simulate sending messages to the VM
             tokio::spawn(async move {

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -189,7 +189,7 @@ mod tests {
             OpCode::ReceiveMessage,
         ];
 
-        let (mut vm, _tx) = VM::new(code, None, Backend::default());
+        let (mut vm, _tx) = VM::new(code, None);
 
         // Execute PushConst and SpawnActor
         vm.execution

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -1,4 +1,4 @@
-use raft::vm::{backend::Backend, opcodes::OpCode, value::Value, vm::VM};
+use raft::vm::{opcodes::OpCode, value::Value, vm::VM};
 
 #[tokio::test]
 async fn division_by_zero_returns_error() {
@@ -7,7 +7,7 @@ async fn division_by_zero_returns_error() {
         OpCode::PushConst(Value::Integer(0)),
         OpCode::Div,
     ];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
+    let (mut vm, _tx) = VM::new(code, None);
     let err = vm.run().await.expect_err("expected division by zero error");
     assert_eq!(err.to_string(), "Division by zero");
 }
@@ -15,7 +15,7 @@ async fn division_by_zero_returns_error() {
 #[tokio::test]
 async fn pop_on_empty_stack_returns_error() {
     let code = vec![OpCode::Pop];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
+    let (mut vm, _tx) = VM::new(code, None);
     let err = vm.run().await.expect_err("expected stack underflow");
     assert_eq!(err.to_string(), "Stack underflow");
 }
@@ -26,7 +26,7 @@ async fn swap_on_single_element_stack_returns_error() {
         OpCode::PushConst(Value::Integer(1)),
         OpCode::Swap,
     ];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
+    let (mut vm, _tx) = VM::new(code, None);
     let err = vm.run().await.expect_err("expected stack underflow for swap");
     assert_eq!(err.to_string(), "Stack underflow for Swap");
 }


### PR DESCRIPTION
## Summary
- update VM::new usage in `handle_run`
- drop `Backend` usage from unit tests
- revise documentation to remove obsolete `Backend` references

## Testing
- `cargo test` *(fails: unexpected closing delimiter in src/vm/error.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c15fe71c8328ac7f6d5d7827fbc5