### PR TITLE
Refactor VmError enum

### DIFF
--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -1,42 +1,10 @@
-use std::fmt;
+use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
 
 use crate::vm::value::Value;
 
-#[derive(Debug, Error, Clone)]
+#[derive(Error, Debug, Clone)]
 pub enum VmError {
-    Message(String),
-    TypeMismatch,
-}
-
-impl From<String> for VmError {
-    fn from(value: String) -> Self {
-        VmError::Message(value)
-    }
-}
-
-impl From<&str> for VmError {
-    fn from(value: &str) -> Self {
-        VmError::Message(value.to_string())
-    }
-}
-
-impl From<SendError<Value>> for VmError {
-    fn from(err: SendError<Value>) -> Self {
-        VmError::Message(err.to_string())
-    }
-}
-
-impl fmt::Display for VmError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            VmError::Message(msg) => write!(f, "{}", msg),
-            VmError::TypeMismatch => write!(f, "Type mismatch"),
-        }
-    }
-}
-
-impl std::error::Error for VmError {}
     #[error("Stack underflow")]
     StackUnderflow,
     #[error("Type mismatch in {0}")]
@@ -57,4 +25,22 @@ impl std::error::Error for VmError {}
     ChannelSend(String),
     #[error("Compilation error: {0}")]
     CompilationError(String),
+}
+
+impl From<String> for VmError {
+    fn from(value: String) -> Self {
+        VmError::CompilationError(value)
+    }
+}
+
+impl From<&str> for VmError {
+    fn from(value: &str) -> Self {
+        VmError::CompilationError(value.to_string())
+    }
+}
+
+impl From<SendError<Value>> for VmError {
+    fn from(err: SendError<Value>) -> Self {
+        VmError::ChannelSend(err.to_string())
+    }
 }

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -96,10 +96,7 @@ impl OpCode {
                 Ok(())
             }
             OpCode::Pop => {
-                execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
+                execution.stack.pop().ok_or(VmError::StackUnderflow)?;
                 Ok(())
             }
             OpCode::Dup => {
@@ -153,17 +150,15 @@ impl OpCode {
                 execution.ip = *target;
                 Ok(())
             }
-            OpCode::JumpIfFalse(target) => {
-                match execution.stack.pop() {
-                    Some(Value::Boolean(false)) => {
-                        execution.ip = *target;
-                        Ok(())
-                    }
-                    Some(Value::Boolean(true)) => Ok(()),
-                    Some(_) => Err(VmError::TypeMismatch),
-                    None => Err("Stack underflow for JumpIfFalse".into()),
+            OpCode::JumpIfFalse(target) => match execution.stack.pop() {
+                Some(Value::Boolean(false)) => {
+                    execution.ip = *target;
+                    Ok(())
                 }
-            }
+                Some(Value::Boolean(true)) => Ok(()),
+                Some(_) => Err(VmError::TypeMismatch("JumpIfFalse")),
+                None => Err(VmError::StackUnderflow),
+            },
             OpCode::Call(addr) => {
                 execution.call_stack.push(execution.ip);
                 execution.ip = *addr;
@@ -197,14 +192,8 @@ impl OpCode {
                 Ok(())
             }
             OpCode::SendMessage => {
-                let actor_ref = execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
-                let message = execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
+                let actor_ref = execution.stack.pop().ok_or(VmError::StackUnderflow)?;
+                let message = execution.stack.pop().ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(address) = actor_ref {
                     if let Some(HeapObject::Actor(_actor_vm, sender, _)) = _heap.get(address) {
                         sender.send(message).await.map_err(VmError::from)?;
@@ -215,7 +204,6 @@ impl OpCode {
                     }
                 } else {
                     Err(VmError::InvalidReference)
-
                 }
             }
             OpCode::SpawnSupervisor(addr) => {
@@ -227,10 +215,7 @@ impl OpCode {
                 Ok(())
             }
             OpCode::SetStrategy(strategy) => {
-                let sup_ref = execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
+                let sup_ref = execution.stack.pop().ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _, _)) = _heap.get_mut(addr) {
                         vm.set_strategy(*strategy);
@@ -241,14 +226,10 @@ impl OpCode {
                     }
                 } else {
                     Err(VmError::InvalidReference)
-
                 }
             }
             OpCode::RestartChild(child) => {
-                let sup_ref = execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
+                let sup_ref = execution.stack.pop().ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _, _)) = _heap.get_mut(addr) {
                         vm.restart_child(*child);
@@ -261,7 +242,6 @@ impl OpCode {
                     Err(VmError::InvalidReference)
                 }
             }
-
         }
     }
 }

--- a/tests/jump_if_false.rs
+++ b/tests/jump_if_false.rs
@@ -1,8 +1,8 @@
-use raft::vm::opcodes::OpCode;
+use raft::vm::error::VmError;
 use raft::vm::execution::ExecutionContext;
 use raft::vm::heap::Heap;
+use raft::vm::opcodes::OpCode;
 use raft::vm::value::Value;
-use raft::vm::error::VmError;
 use tokio::sync::mpsc::channel;
 
 #[tokio::test]
@@ -11,6 +11,8 @@ async fn jump_if_false_errors_on_non_boolean() {
     ctx.stack.push(Value::Integer(42));
     let mut heap = Heap::new();
     let (_tx, mut rx) = channel(1);
-    let result = OpCode::JumpIfFalse(0).execute(&mut ctx, &mut heap, &mut rx).await;
-    assert!(matches!(result, Err(VmError::TypeMismatch)));
+    let result = OpCode::JumpIfFalse(0)
+        .execute(&mut ctx, &mut heap, &mut rx)
+        .await;
+    assert!(matches!(result, Err(VmError::TypeMismatch(_))));
 }


### PR DESCRIPTION
## Summary
- Replace VmError with a single enum covering stack, type, division, execution, variable and messaging errors
- Update channel, stack, and jump-if-false code to use new VmError variants
- Adjust tests to match updated TypeMismatch variant

## Testing
- `cargo fmt`
- `cargo test` *(fails: use of undeclared type `Backend`)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c160c1d08328a13d4d91782321ea