### PR TITLE
Introduce structured compiler errors and propagate through VM

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod compiler;
 pub mod runtime;
 pub mod vm;
 
-pub use compiler::Compiler;
+pub use compiler::{Compiler, CompilerError};
 pub use runtime::Actor;
 pub use vm::VM;
 
@@ -14,7 +14,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Runs a Raft program from source code
 pub async fn run(source: &str) -> Result<(), VmError> {
-    let bytecode = Compiler::compile(source).map_err(VmError::CompilationError)?;
+    let bytecode = Compiler::compile(source)?;
 
     let (mut vm, _tx) = VM::new(bytecode, None);
     vm.run().await

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::process;
 
 use raft::compiler::Compiler;
 use raft::vm::value::Value;
-use raft::vm::VM;
+use raft::vm::{VmError, VM};
 
 use std::io::Write;
 use tokio::io::{self, AsyncBufReadExt};
@@ -65,11 +65,12 @@ async fn handle_run(filename: &str) {
             let bytecode = match Compiler::compile(&source) {
                 Ok(b) => b,
                 Err(e) => {
-                    eprintln!("Compilation error: {}", e);
+                    let err: VmError = e.into();
+                    eprintln!("{}", err);
                     process::exit(1);
                 }
             };
-            let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+            let (mut vm, tx) = VM::new(bytecode, None);
 
             // Simulate sending messages to the VM
             tokio::spawn(async move {

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -112,7 +112,7 @@ impl OpCode {
             }
             OpCode::Swap => {
                 if execution.stack.len() < 2 {
-                    return Err(VmError::StackUnderflow);
+                    return Err(VmError::StackUnderflowFor("Swap"));
                 }
                 let len = execution.stack.len();
                 execution.stack.swap(len - 1, len - 2);
@@ -160,8 +160,8 @@ impl OpCode {
                         Ok(())
                     }
                     Some(Value::Boolean(true)) => Ok(()),
-                    Some(_) => Err(VmError::TypeMismatch),
-                    None => Err("Stack underflow for JumpIfFalse".into()),
+                    Some(_) => Err(VmError::TypeMismatch("JumpIfFalse")),
+                    None => Err(VmError::StackUnderflowFor("JumpIfFalse")),
                 }
             }
             OpCode::Call(addr) => {

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -189,7 +189,7 @@ mod tests {
             OpCode::ReceiveMessage,
         ];
 
-        let (mut vm, _tx) = VM::new(code, None, Backend::default());
+        let (mut vm, _tx) = VM::new(code, None);
 
         // Execute PushConst and SpawnActor
         vm.execution

--- a/tests/jump_if_false.rs
+++ b/tests/jump_if_false.rs
@@ -12,5 +12,5 @@ async fn jump_if_false_errors_on_non_boolean() {
     let mut heap = Heap::new();
     let (_tx, mut rx) = channel(1);
     let result = OpCode::JumpIfFalse(0).execute(&mut ctx, &mut heap, &mut rx).await;
-    assert!(matches!(result, Err(VmError::TypeMismatch)));
+    assert!(matches!(result, Err(VmError::TypeMismatch("JumpIfFalse"))));
 }

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -1,4 +1,4 @@
-use raft::vm::{backend::Backend, opcodes::OpCode, value::Value, vm::VM};
+use raft::vm::{opcodes::OpCode, value::Value, vm::VM};
 
 #[tokio::test]
 async fn division_by_zero_returns_error() {
@@ -7,7 +7,7 @@ async fn division_by_zero_returns_error() {
         OpCode::PushConst(Value::Integer(0)),
         OpCode::Div,
     ];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
+    let (mut vm, _tx) = VM::new(code, None);
     let err = vm.run().await.expect_err("expected division by zero error");
     assert_eq!(err.to_string(), "Division by zero");
 }
@@ -15,7 +15,7 @@ async fn division_by_zero_returns_error() {
 #[tokio::test]
 async fn pop_on_empty_stack_returns_error() {
     let code = vec![OpCode::Pop];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
+    let (mut vm, _tx) = VM::new(code, None);
     let err = vm.run().await.expect_err("expected stack underflow");
     assert_eq!(err.to_string(), "Stack underflow");
 }
@@ -26,7 +26,7 @@ async fn swap_on_single_element_stack_returns_error() {
         OpCode::PushConst(Value::Integer(1)),
         OpCode::Swap,
     ];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
+    let (mut vm, _tx) = VM::new(code, None);
     let err = vm.run().await.expect_err("expected stack underflow for swap");
     assert_eq!(err.to_string(), "Stack underflow for Swap");
 }


### PR DESCRIPTION
## Summary
- Add `CompilerError` enum and refactor compiler to return it
- Wrap compilation failures in `VmError::CompilationError`
- Update CLI and library to handle structured errors
- Add tests for invalid tokens, addresses, parse errors and propagation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c16268288328ba8d385f422874f8