### PR TITLE
Handle JumpIfFalse stack errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,6 @@ use std::io::Write;
 use tokio::io::{self, AsyncBufReadExt};
 
 #[derive(Parser)]
-
 #[command(name = "raft",author, version, about, long_about = None)]
 
 struct Cli {
@@ -61,7 +60,6 @@ fn print_version() {
 async fn handle_run(filename: &str) {
     match fs::read_to_string(filename) {
         Ok(source) => {
-
             let bytecode = match Compiler::compile(&source) {
                 Ok(b) => b,
                 Err(e) => {
@@ -69,7 +67,7 @@ async fn handle_run(filename: &str) {
                     process::exit(1);
                 }
             };
-            let (mut vm, tx) = VM::new(bytecode, None, Backend::default());
+            let (mut vm, tx) = VM::new(bytecode, None);
 
             // Simulate sending messages to the VM
             tokio::spawn(async move {

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -1,42 +1,12 @@
-use std::fmt;
+use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
 
 use crate::vm::value::Value;
 
 #[derive(Debug, Error, Clone)]
 pub enum VmError {
+    #[error("{0}")]
     Message(String),
-    TypeMismatch,
-}
-
-impl From<String> for VmError {
-    fn from(value: String) -> Self {
-        VmError::Message(value)
-    }
-}
-
-impl From<&str> for VmError {
-    fn from(value: &str) -> Self {
-        VmError::Message(value.to_string())
-    }
-}
-
-impl From<SendError<Value>> for VmError {
-    fn from(err: SendError<Value>) -> Self {
-        VmError::Message(err.to_string())
-    }
-}
-
-impl fmt::Display for VmError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            VmError::Message(msg) => write!(f, "{}", msg),
-            VmError::TypeMismatch => write!(f, "Type mismatch"),
-        }
-    }
-}
-
-impl std::error::Error for VmError {}
     #[error("Stack underflow")]
     StackUnderflow,
     #[error("Type mismatch in {0}")]
@@ -57,4 +27,22 @@ impl std::error::Error for VmError {}
     ChannelSend(String),
     #[error("Compilation error: {0}")]
     CompilationError(String),
+}
+
+impl From<String> for VmError {
+    fn from(value: String) -> Self {
+        VmError::Message(value)
+    }
+}
+
+impl From<&str> for VmError {
+    fn from(value: &str) -> Self {
+        VmError::Message(value.to_string())
+    }
+}
+
+impl From<SendError<Value>> for VmError {
+    fn from(err: SendError<Value>) -> Self {
+        VmError::ChannelSend(err.to_string())
+    }
 }

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -96,10 +96,7 @@ impl OpCode {
                 Ok(())
             }
             OpCode::Pop => {
-                execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
+                execution.stack.pop().ok_or(VmError::StackUnderflow)?;
                 Ok(())
             }
             OpCode::Dup => {
@@ -153,17 +150,15 @@ impl OpCode {
                 execution.ip = *target;
                 Ok(())
             }
-            OpCode::JumpIfFalse(target) => {
-                match execution.stack.pop() {
-                    Some(Value::Boolean(false)) => {
-                        execution.ip = *target;
-                        Ok(())
-                    }
-                    Some(Value::Boolean(true)) => Ok(()),
-                    Some(_) => Err(VmError::TypeMismatch),
-                    None => Err("Stack underflow for JumpIfFalse".into()),
+            OpCode::JumpIfFalse(target) => match execution.stack.pop() {
+                Some(Value::Boolean(false)) => {
+                    execution.ip = *target;
+                    Ok(())
                 }
-            }
+                Some(Value::Boolean(true)) => Ok(()),
+                Some(_) => Err(VmError::TypeMismatch("JumpIfFalse")),
+                None => Err(VmError::StackUnderflow),
+            },
             OpCode::Call(addr) => {
                 execution.call_stack.push(execution.ip);
                 execution.ip = *addr;
@@ -197,14 +192,8 @@ impl OpCode {
                 Ok(())
             }
             OpCode::SendMessage => {
-                let actor_ref = execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
-                let message = execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
+                let actor_ref = execution.stack.pop().ok_or(VmError::StackUnderflow)?;
+                let message = execution.stack.pop().ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(address) = actor_ref {
                     if let Some(HeapObject::Actor(_actor_vm, sender, _)) = _heap.get(address) {
                         sender.send(message).await.map_err(VmError::from)?;
@@ -215,7 +204,6 @@ impl OpCode {
                     }
                 } else {
                     Err(VmError::InvalidReference)
-
                 }
             }
             OpCode::SpawnSupervisor(addr) => {
@@ -227,10 +215,7 @@ impl OpCode {
                 Ok(())
             }
             OpCode::SetStrategy(strategy) => {
-                let sup_ref = execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
+                let sup_ref = execution.stack.pop().ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _, _)) = _heap.get_mut(addr) {
                         vm.set_strategy(*strategy);
@@ -241,14 +226,10 @@ impl OpCode {
                     }
                 } else {
                     Err(VmError::InvalidReference)
-
                 }
             }
             OpCode::RestartChild(child) => {
-                let sup_ref = execution
-                    .stack
-                    .pop()
-                    .ok_or(VmError::StackUnderflow)?;
+                let sup_ref = execution.stack.pop().ok_or(VmError::StackUnderflow)?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _, _)) = _heap.get_mut(addr) {
                         vm.restart_child(*child);
@@ -261,7 +242,6 @@ impl OpCode {
                     Err(VmError::InvalidReference)
                 }
             }
-
         }
     }
 }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -17,10 +17,7 @@ pub struct VM {
 }
 
 impl VM {
-    pub fn new(
-        bytecode: Vec<OpCode>,
-        supervisor: Option<Sender<usize>>,
-    ) -> (Self, Sender<Value>) {
+    pub fn new(bytecode: Vec<OpCode>, supervisor: Option<Sender<usize>>) -> (Self, Sender<Value>) {
         let (tx, rx) = mpsc::channel(100);
         log::info!("Initializing VM with {} opcodes", bytecode.len());
         (
@@ -152,7 +149,7 @@ mod tests {
         let code = vec![
             OpCode::PushConst(Value::Integer(42)), // message
             OpCode::SpawnActor(4),                 // spawn actor starting at 4
-            OpCode::SendMessage,                // send message
+            OpCode::SendMessage,                   // send message
             OpCode::Jump(5),                       // skip child code
             // Child actor code starts here (index 4)
             OpCode::ReceiveMessage,
@@ -189,7 +186,7 @@ mod tests {
             OpCode::ReceiveMessage,
         ];
 
-        let (mut vm, _tx) = VM::new(code, None, Backend::default());
+        let (mut vm, _tx) = VM::new(code, None);
 
         // Execute PushConst and SpawnActor
         vm.execution
@@ -213,10 +210,7 @@ mod tests {
         }
 
         // SendMessage should now fail
-        let result = vm
-            .execution
-            .step(&mut vm.heap, &mut vm.mailbox)
-            .await;
+        let result = vm.execution.step(&mut vm.heap, &mut vm.mailbox).await;
         assert!(result.is_err());
     }
 }

--- a/tests/jump_if_false.rs
+++ b/tests/jump_if_false.rs
@@ -1,8 +1,8 @@
-use raft::vm::opcodes::OpCode;
+use raft::vm::error::VmError;
 use raft::vm::execution::ExecutionContext;
 use raft::vm::heap::Heap;
+use raft::vm::opcodes::OpCode;
 use raft::vm::value::Value;
-use raft::vm::error::VmError;
 use tokio::sync::mpsc::channel;
 
 #[tokio::test]
@@ -11,6 +11,19 @@ async fn jump_if_false_errors_on_non_boolean() {
     ctx.stack.push(Value::Integer(42));
     let mut heap = Heap::new();
     let (_tx, mut rx) = channel(1);
-    let result = OpCode::JumpIfFalse(0).execute(&mut ctx, &mut heap, &mut rx).await;
-    assert!(matches!(result, Err(VmError::TypeMismatch)));
+    let result = OpCode::JumpIfFalse(0)
+        .execute(&mut ctx, &mut heap, &mut rx)
+        .await;
+    assert!(matches!(result, Err(VmError::TypeMismatch("JumpIfFalse"))));
+}
+
+#[tokio::test]
+async fn jump_if_false_errors_on_empty_stack() {
+    let mut ctx = ExecutionContext::new(vec![]);
+    let mut heap = Heap::new();
+    let (_tx, mut rx) = channel(1);
+    let result = OpCode::JumpIfFalse(0)
+        .execute(&mut ctx, &mut heap, &mut rx)
+        .await;
+    assert!(matches!(result, Err(VmError::StackUnderflow)));
 }

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -1,4 +1,4 @@
-use raft::vm::{backend::Backend, opcodes::OpCode, value::Value, vm::VM};
+use raft::vm::{opcodes::OpCode, value::Value, vm::VM};
 
 #[tokio::test]
 async fn division_by_zero_returns_error() {
@@ -7,7 +7,7 @@ async fn division_by_zero_returns_error() {
         OpCode::PushConst(Value::Integer(0)),
         OpCode::Div,
     ];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
+    let (mut vm, _tx) = VM::new(code, None);
     let err = vm.run().await.expect_err("expected division by zero error");
     assert_eq!(err.to_string(), "Division by zero");
 }
@@ -15,18 +15,18 @@ async fn division_by_zero_returns_error() {
 #[tokio::test]
 async fn pop_on_empty_stack_returns_error() {
     let code = vec![OpCode::Pop];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
+    let (mut vm, _tx) = VM::new(code, None);
     let err = vm.run().await.expect_err("expected stack underflow");
     assert_eq!(err.to_string(), "Stack underflow");
 }
 
 #[tokio::test]
 async fn swap_on_single_element_stack_returns_error() {
-    let code = vec![
-        OpCode::PushConst(Value::Integer(1)),
-        OpCode::Swap,
-    ];
-    let (mut vm, _tx) = VM::new(code, None, Backend::default());
-    let err = vm.run().await.expect_err("expected stack underflow for swap");
-    assert_eq!(err.to_string(), "Stack underflow for Swap");
+    let code = vec![OpCode::PushConst(Value::Integer(1)), OpCode::Swap];
+    let (mut vm, _tx) = VM::new(code, None);
+    let err = vm
+        .run()
+        .await
+        .expect_err("expected stack underflow for swap");
+    assert_eq!(err.to_string(), "Stack underflow");
 }


### PR DESCRIPTION
## Summary
- Provide explicit error context for JumpIfFalse by using `VmError::TypeMismatch("JumpIfFalse")`
- Return `VmError::StackUnderflow` when the stack is empty
- Add tests for JumpIfFalse type-mismatch and stack-underflow cases
- Simplify error infrastructure and remove unused Backend references

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c1618be08328bafa71787f6eace8