### PR TITLE
Fix JumpIfFalse reference handling

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -200,14 +200,13 @@ impl OpCode {
                 Ok(())
             }
 
-            OpCode::JumpIfFalse(target) => match execution.stack.pop() {
-                Some(Value::Boolean(false)) => {
+            OpCode::JumpIfFalse(target) => match pop_value(execution, heap) {
+                Ok(Value::Boolean(false)) => {
                     execution.ip = *target;
                     Ok(())
                 }
                 Ok(Value::Boolean(true)) => Ok(()),
                 Ok(_) => Err(VmError::TypeMismatch("JumpIfFalse")),
-                Err(VmError::StackUnderflow) => Err(VmError::StackUnderflow),
                 Err(e) => Err(e),
             },
             OpCode::Call(addr) => {

--- a/tests/jump_if_false.rs
+++ b/tests/jump_if_false.rs
@@ -1,6 +1,6 @@
 use raft::vm::error::VmError;
 use raft::vm::execution::ExecutionContext;
-use raft::vm::heap::Heap;
+use raft::vm::heap::{Heap, HeapObject};
 use raft::vm::opcodes::OpCode;
 use raft::vm::value::Value;
 use tokio::sync::mpsc::channel;
@@ -26,4 +26,58 @@ async fn jump_if_false_errors_on_empty_stack() {
         .execute(&mut ctx, &mut heap, &mut rx)
         .await;
     assert!(matches!(result, Err(VmError::StackUnderflow)));
+}
+
+fn actor_ref_count(heap: &Heap, address: usize) -> usize {
+    match heap.get(address) {
+        Some(HeapObject::Actor(_, _, rc)) => *rc,
+        _ => panic!("Expected actor at address {address}"),
+    }
+}
+
+#[tokio::test]
+async fn jump_if_false_skips_jump_when_true() {
+    let mut ctx = ExecutionContext::new(vec![]);
+    ctx.stack.push(Value::Boolean(true));
+    ctx.ip = 7;
+    let mut heap = Heap::new();
+    let (_tx, mut rx) = channel(1);
+
+    OpCode::JumpIfFalse(99)
+        .execute(&mut ctx, &mut heap, &mut rx)
+        .await
+        .unwrap();
+
+    assert_eq!(ctx.ip, 7);
+    assert!(ctx.stack.is_empty());
+}
+
+#[tokio::test]
+async fn jump_if_false_drops_reference_on_type_mismatch() {
+    let mut ctx = ExecutionContext::new(vec![]);
+    let mut heap = Heap::new();
+    let (_tx, mut rx) = channel(1);
+
+    OpCode::SpawnActor(0)
+        .execute(&mut ctx, &mut heap, &mut rx)
+        .await
+        .unwrap();
+
+    let address = match ctx.stack.last().copied() {
+        Some(Value::Reference(addr)) => addr,
+        other => panic!("Expected actor reference on stack, got {other:?}"),
+    };
+
+    assert_eq!(actor_ref_count(&heap, address), 1);
+
+    let result = OpCode::JumpIfFalse(0)
+        .execute(&mut ctx, &mut heap, &mut rx)
+        .await;
+
+    assert!(matches!(result, Err(VmError::TypeMismatch("JumpIfFalse"))));
+    assert!(ctx.stack.is_empty());
+    assert_eq!(actor_ref_count(&heap, address), 0);
+
+    heap.collect_garbage();
+    assert!(heap.get(address).is_none());
 }


### PR DESCRIPTION
## Summary
- update JumpIfFalse to use pop_value so non-boolean conditions release their references
- make the opcode jump only on Boolean(false) and surface TypeMismatch for other values
- extend JumpIfFalse tests to cover the true case and ensure references are dropped on errors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_69020de5418483289771c877fe45cc77