### PR TITLE
Handle top-level Return opcode as graceful halt

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -247,7 +247,8 @@ impl OpCode {
                     execution.ip = return_addr;
                     Ok(())
                 } else {
-                    Err(VmError::StackUnderflow)
+                    execution.ip = execution.bytecode.len();
+                    Ok(())
                 }
             }
             OpCode::ReceiveMessage => {

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -88,3 +88,11 @@ async fn spawn_supervisor_out_of_bounds_returns_error() {
         .expect_err("expected execution out of bounds for spawn supervisor");
     assert!(matches!(err, VmError::ExecutionOutOfBounds));
 }
+
+#[tokio::test]
+async fn top_level_return_gracefully_halts_vm() {
+    let code = vec![OpCode::Return];
+    let (mut vm, _tx) = VM::new(code, None);
+    let result = vm.run().await;
+    assert!(result.is_ok(), "expected top-level return to halt gracefully");
+}


### PR DESCRIPTION
### Motivation
- Allow a top-level `Return` to terminate the VM cleanly instead of treating it as a stack underflow when `execution.call_stack` is empty, matching a natural program halt behavior for a top-level return.

### Description
- Change `OpCode::Return` in `src/vm/opcodes.rs` so that when `execution.call_stack.pop()` yields `None` it sets `execution.ip = execution.bytecode.len()` and returns `Ok(())`, while keeping the existing behavior when a return address exists.
- Add a test `top_level_return_gracefully_halts_vm` to `tests/vm_errors.rs` that runs bytecode `[OpCode::Return]` and asserts `vm.run()` completes with `Ok(())`.

### Testing
- Ran `cargo test --test vm_errors` and the test suite for that file passed (9 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17e1513b88328bf023c27cab2d8a5)