### PR TITLE
Stabilize SendMessage stack behavior on send failure

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -279,6 +279,9 @@ impl OpCode {
                 push_value(execution, heap, Value::Reference(address))
             }
             OpCode::SendMessage => {
+                // SendMessage has stack-stable behavior for actor references:
+                // the actor reference is present on the stack after the opcode
+                // finishes, regardless of success or failure.
                 let actor_ref = pop_value(execution, heap)?;
                 let message = pop_value(execution, heap)?;
                 if let Value::Reference(address) = actor_ref {
@@ -294,6 +297,7 @@ impl OpCode {
                         Err(err) => {
                             let error = err.to_string();
                             let failed_message = err.0;
+                            push_value(execution, heap, Value::Reference(address))?;
                             // Keep the recovered message alive so that callers can
                             // safely inspect or resend it from the returned error.
                             // The send attempt already incremented the reference

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -1,4 +1,7 @@
+use raft::vm::execution::ExecutionContext;
+use raft::vm::heap::{Heap, HeapObject};
 use raft::vm::{error::VmError, opcodes::OpCode, value::Value, vm::VM};
+use tokio::sync::mpsc::channel;
 
 #[tokio::test]
 async fn division_by_zero_returns_error() {
@@ -87,4 +90,75 @@ async fn spawn_supervisor_out_of_bounds_returns_error() {
         .await
         .expect_err("expected execution out of bounds for spawn supervisor");
     assert!(matches!(err, VmError::ExecutionOutOfBounds));
+}
+
+#[tokio::test]
+async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
+    let mut execution = ExecutionContext::new(vec![OpCode::Return]);
+    let mut heap = Heap::new();
+    let (_tx, mut mailbox) = channel(1);
+
+    // Stack layout expected by SendMessage is [message, actor_ref].
+    OpCode::SpawnActor(0)
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .expect("spawn actor should succeed");
+    let actor_addr = match execution.stack.last().copied() {
+        Some(Value::Reference(addr)) => addr,
+        other => panic!("expected actor reference, got {other:?}"),
+    };
+
+    let message_addr = heap.allocate(HeapObject::Array(vec![], 0));
+    OpCode::PushConst(Value::Reference(message_addr))
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .expect("push message reference should succeed");
+    OpCode::Swap
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .expect("swap should succeed");
+
+    // Close actor mailbox to force ChannelSend error.
+    let actor_entry = heap
+        .get_mut(actor_addr)
+        .expect("spawned actor should be in heap");
+    match actor_entry {
+        HeapObject::Actor(actor_vm, _, _) => actor_vm.mailbox.close(),
+        other => panic!("expected actor in heap, got {other:?}"),
+    }
+
+    let err = OpCode::SendMessage
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .expect_err("send should fail when mailbox is closed");
+
+    match err {
+        VmError::ChannelSend { value, .. } => {
+            assert_eq!(value, Value::Reference(message_addr));
+        }
+        other => panic!("expected ChannelSend error, got {other:?}"),
+    }
+
+    assert_eq!(
+        execution.stack,
+        vec![Value::Reference(actor_addr)],
+        "actor reference should be restored on failure",
+    );
+
+    match heap.get(actor_addr).expect("actor should remain allocated") {
+        HeapObject::Actor(_, _, rc) => assert_eq!(*rc, 1, "actor should have stack ref"),
+        other => panic!("expected actor at actor_addr, got {other:?}"),
+    }
+    match heap
+        .get(message_addr)
+        .expect("message object should remain allocated")
+    {
+        HeapObject::Array(_, rc) => {
+            assert_eq!(
+                *rc, 1,
+                "failed_message in ChannelSend should own exactly one reference",
+            )
+        }
+        other => panic!("expected array at message_addr, got {other:?}"),
+    }
 }


### PR DESCRIPTION
### Motivation

- Make `OpCode::SendMessage` behavior deterministic so callers observe the same VM stack shape whether the send succeeds or fails. 
- Prevent reference-counting surprises and accidental leaks when a channel send fails and the message is recovered. 

### Description

- Chose behavior A: the actor reference is preserved on the stack after a `SendMessage` attempt, and this is documented in `src/vm/opcodes.rs` near the `SendMessage` handler. 
- Restored the actor ref onto the stack in the error branch before returning `VmError::ChannelSend` by calling `push_value(...)` on the recovered actor reference. 
- Kept message ownership semantics intact by reusing the recovered `failed_message` as the `ChannelSend` payload without introducing extra reference increments. 
- Added an integration test `send_message_failure_preserves_actor_on_stack_and_ref_counts` in `tests/vm_errors.rs` that forces a mailbox closure and asserts stack shape, actor/message refcounts, and the returned error payload. 

### Testing

- Ran `cargo test --test vm_errors --test reference_counts` to exercise the modified send logic and refcount tests. 
- `tests/reference_counts.rs` ran and all tests passed (`3 passed; 0 failed`). 
- `tests/vm_errors.rs` ran and all tests passed including the new failure test (`9 passed; 0 failed`). 
- The combined test run completed with all targeted tests green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17e12fc98832889b2206db6ef7683)