### PR TITLE
Refcount-aware operand consumption in arithmetic opcodes

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -7,32 +7,28 @@ use crate::vm::value::Value;
 use crate::vm::vm::VM;
 use tokio::sync::mpsc::Receiver;
 
-fn unary_op<F>(stack: &mut Vec<Value>, f: F) -> Result<(), VmError>
+fn unary_op<F>(execution: &mut ExecutionContext, heap: &mut Heap, f: F) -> Result<(), VmError>
 where
     F: Fn(Value) -> Result<Value, VmError>,
 {
-    if let Some(v) = stack.pop() {
-        let result = f(v)?;
-        stack.push(result);
-        Ok(())
-    } else {
-        log::error!("Stack underflow during unary operation");
-        Err(VmError::StackUnderflow)
-    }
+    let v = pop_value(execution, heap)?;
+    let result = f(v)?;
+    execution.stack.push(result);
+    Ok(())
 }
 
-fn binary_op<F>(stack: &mut Vec<Value>, f: F) -> Result<(), VmError>
+fn binary_op<F>(execution: &mut ExecutionContext, heap: &mut Heap, f: F) -> Result<(), VmError>
 where
     F: Fn(Value, Value) -> Result<Value, VmError>,
 {
-    if stack.len() < 2 {
+    if execution.stack.len() < 2 {
         log::error!("Stack underflow during binary operation");
         return Err(VmError::StackUnderflow);
     }
-    let b = stack.pop().unwrap();
-    let a = stack.pop().unwrap();
+    let b = pop_value(execution, heap)?;
+    let a = pop_value(execution, heap)?;
     let result = f(a, b)?;
-    stack.push(result);
+    execution.stack.push(result);
     Ok(())
 }
 
@@ -123,11 +119,11 @@ impl OpCode {
         mailbox: &mut Receiver<Value>,
     ) -> Result<(), VmError> {
         match self {
-            OpCode::Add => binary_op(&mut execution.stack, |a, b| a.add(b)),
-            OpCode::Sub => binary_op(&mut execution.stack, |a, b| a.sub(b)),
-            OpCode::Mul => binary_op(&mut execution.stack, |a, b| a.mul(b)),
-            OpCode::Div => binary_op(&mut execution.stack, |a, b| a.div(b)),
-            OpCode::Neg => unary_op(&mut execution.stack, |a| match a {
+            OpCode::Add => binary_op(execution, heap, |a, b| a.add(b)),
+            OpCode::Sub => binary_op(execution, heap, |a, b| a.sub(b)),
+            OpCode::Mul => binary_op(execution, heap, |a, b| a.mul(b)),
+            OpCode::Div => binary_op(execution, heap, |a, b| a.div(b)),
+            OpCode::Neg => unary_op(execution, heap, |a| match a {
                 Value::Integer(i) => Ok(Value::Integer(-i)),
                 Value::Float(f) => Ok(Value::Float(-f)),
                 _ => Err(VmError::TypeMismatch("Neg")),
@@ -174,7 +170,7 @@ impl OpCode {
                     Err(VmError::VariableNotFound(*index))
                 }
             }
-            OpCode::Mod => binary_op(&mut execution.stack, |a, b| match (a, b) {
+            OpCode::Mod => binary_op(execution, heap, |a, b| match (a, b) {
                 (Value::Integer(x), Value::Integer(y)) => {
                     if y == 0 {
                         Err(VmError::DivisionByZero)
@@ -184,7 +180,7 @@ impl OpCode {
                 }
                 _ => Err(VmError::TypeMismatch("Mod")),
             }),
-            OpCode::Exp => binary_op(&mut execution.stack, |a, b| match (a, b) {
+            OpCode::Exp => binary_op(execution, heap, |a, b| match (a, b) {
                 (Value::Integer(x), Value::Integer(y)) => {
                     if y < 0 {
                         Ok(Value::Float((x as f64).powi(y)))

--- a/tests/reference_counts.rs
+++ b/tests/reference_counts.rs
@@ -157,3 +157,84 @@ async fn vm_pop_stack_drops_actor_reference() {
         "actor should be collected after reference count reaches zero"
     );
 }
+
+#[tokio::test]
+async fn neg_type_mismatch_consumes_reference_operand() {
+    let mut execution = ExecutionContext::new(vec![OpCode::Return]);
+    let mut heap = Heap::new();
+    let (_tx, mut mailbox) = channel(1);
+
+    OpCode::SpawnActor(0)
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .unwrap();
+
+    let address = match execution.stack.last().copied() {
+        Some(Value::Reference(addr)) => addr,
+        other => panic!("Expected actor reference on stack, got {other:?}"),
+    };
+
+    let err = OpCode::Neg
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, raft::vm::error::VmError::TypeMismatch("Neg")));
+    assert!(execution.stack.is_empty(), "operand should be consumed");
+    assert_eq!(actor_ref_count(&heap, address), 0);
+
+    heap.collect_garbage();
+    assert!(heap.get(address).is_none());
+}
+
+#[tokio::test]
+async fn add_and_mod_type_mismatch_do_not_leak_references() {
+    let mut execution = ExecutionContext::new(vec![OpCode::Return]);
+    let mut heap = Heap::new();
+    let (_tx, mut mailbox) = channel(1);
+
+    OpCode::SpawnActor(0)
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .unwrap();
+    let add_ref = match execution.stack.last().copied() {
+        Some(Value::Reference(addr)) => addr,
+        other => panic!("Expected actor reference on stack, got {other:?}"),
+    };
+    execution.stack.push(Value::Integer(1));
+
+    let add_err = OpCode::Add
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        add_err,
+        raft::vm::error::VmError::TypeMismatch("Add")
+    ));
+    assert!(execution.stack.is_empty(), "operands should be consumed");
+    assert_eq!(actor_ref_count(&heap, add_ref), 0);
+
+    OpCode::SpawnActor(0)
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .unwrap();
+    let mod_ref = match execution.stack.last().copied() {
+        Some(Value::Reference(addr)) => addr,
+        other => panic!("Expected actor reference on stack, got {other:?}"),
+    };
+    execution.stack.push(Value::Integer(2));
+
+    let mod_err = OpCode::Mod
+        .execute(&mut execution, &mut heap, &mut mailbox)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        mod_err,
+        raft::vm::error::VmError::TypeMismatch("Mod")
+    ));
+    assert!(execution.stack.is_empty(), "operands should be consumed");
+    assert_eq!(actor_ref_count(&heap, mod_ref), 0);
+
+    heap.collect_garbage();
+    assert!(heap.get(add_ref).is_none());
+    assert!(heap.get(mod_ref).is_none());
+}


### PR DESCRIPTION
### Motivation
- Ensure reference-counted heap objects are decremented when arithmetic opcodes consume operands so failed operations do not leak references. 
- Preserve the model that an operand is "consumed on attempt" even if the operation returns an error. 
- Avoid special-case reference handling scattered across opcode handlers by centralizing consumption logic.

### Description
- Changed `unary_op` and `binary_op` signatures to accept `&mut ExecutionContext` and `&mut Heap` and to pop operands via `pop_value(execution, heap)` so reference counts are decremented when operands are consumed. 
- Updated arithmetic opcode handlers (`Add`, `Sub`, `Mul`, `Div`, `Mod`, `Exp`, `Neg`) to call the new helpers (`binary_op(execution, heap, ...)` / `unary_op(execution, heap, ...)`). 
- Kept error semantics such that if popping succeeds but the operation closure returns an error, the consumed operand references remain decremented. 
- Added regression tests in `tests/reference_counts.rs` covering `Neg` type-mismatch on a reference operand and `Add`/`Mod` type-mismatch cases to assert operands are consumed and no references are leaked, and adjusted error assertions to use `matches!` for `VmError` patterns.

### Testing
- Ran `cargo test --test reference_counts` which compiled and executed the reference-count tests successfully. 
- All tests in that suite passed: 5 passed, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17e11f8a48328ae540c08a9e4e829)