### PR TITLE
Optimize VM dispatch loop and add dense bytecode format

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -39,9 +39,9 @@ impl Compiler {
                                 "expected variable index after StoreVar".into(),
                             )
                         })?;
-                        let index = index_token.parse::<usize>().map_err(|_| {
-                            CompilerError::InvalidAddress(index_token.to_string())
-                        })?;
+                        let index = index_token
+                            .parse::<usize>()
+                            .map_err(|_| CompilerError::InvalidAddress(index_token.to_string()))?;
                         bytecode.push(OpCode::StoreVar(index));
                     }
                     "LoadVar" => {
@@ -50,9 +50,9 @@ impl Compiler {
                                 "expected variable index after LoadVar".into(),
                             )
                         })?;
-                        let index = index_token.parse::<usize>().map_err(|_| {
-                            CompilerError::InvalidAddress(index_token.to_string())
-                        })?;
+                        let index = index_token
+                            .parse::<usize>()
+                            .map_err(|_| CompilerError::InvalidAddress(index_token.to_string()))?;
                         bytecode.push(OpCode::LoadVar(index));
                     }
                     "Pop" => bytecode.push(OpCode::Pop),

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,7 @@ use std::io::Write;
 use tokio::io::{self, AsyncBufReadExt};
 
 #[derive(Parser)]
-#[command(name = "raft",author, version, about, long_about = None)]
-
+#[command(name = "raft", author, version, about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -41,6 +41,6 @@ impl Actor {
 
     /// Receive the next message if available.
     pub async fn handle_next_message(&mut self) -> Option<Value> {
-        self.vm.mailbox.recv().await
+        self.vm.mailbox_mut().recv().await
     }
 }

--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::vm::error::VmError;
 use crate::vm::heap::Heap;
-use crate::vm::opcodes::OpCode;
+use crate::vm::opcodes::{Bytecode, ExecutionState, OpCode};
 use crate::vm::value::Value;
 
 use tokio::sync::mpsc::Receiver;
@@ -15,35 +15,49 @@ pub struct ExecutionContext {
     pub locals: HashMap<usize, Value>,
     pub ip: usize,
     pub call_stack: Vec<usize>,
-    pub bytecode: Vec<OpCode>,
+    pub bytecode: Bytecode,
+    pub mailbox: Receiver<Value>,
+    pub(crate) pending_receive: Option<Value>,
 }
 
 impl ExecutionContext {
     pub fn new(bytecode: Vec<OpCode>) -> Self {
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        Self::with_mailbox(bytecode, rx)
+    }
+
+    pub fn from_bytecode(bytecode: Bytecode, mailbox: Receiver<Value>) -> Self {
         Self {
             stack: Vec::new(),
             locals: HashMap::new(),
             ip: 0,
             call_stack: Vec::new(),
             bytecode,
+            mailbox,
+            pending_receive: None,
         }
     }
 
-    pub async fn step(
-        &mut self,
-        heap: &mut Heap,
-        mailbox: &mut Receiver<Value>,
-    ) -> Result<(), VmError> {
-        if self.ip >= self.bytecode.len() {
+    pub fn with_mailbox<B>(bytecode: B, mailbox: Receiver<Value>) -> Self
+    where
+        B: Into<Bytecode>,
+    {
+        Self::from_bytecode(bytecode.into(), mailbox)
+    }
+
+    pub fn step(&mut self, heap: &mut Heap) -> Result<ExecutionState, VmError> {
+        if self.ip >= self.bytecode.instruction_len() {
+            if self.ip == self.bytecode.instruction_len() {
+                return Ok(ExecutionState::Halted);
+            }
             log::error!("Instruction pointer out of bounds: {}", self.ip);
             return Err(VmError::ExecutionOutOfBounds);
         }
 
-        let opcode = self.bytecode[self.ip].clone();
-        // advance instruction pointer unless opcode modified it
+        let opcode = self.bytecode.decode_at(self.ip)?;
         self.ip += 1;
         log::info!("Executing opcode: {:?}", opcode);
-        opcode.execute(self, heap, mailbox).await
+        opcode.execute(self, heap)
     }
 
     pub fn ip(&self) -> usize {

--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -33,6 +33,12 @@ pub enum HeapObject {
     Supervisor(VM, Sender<Value>, usize),
 }
 
+impl Default for Heap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Heap {
     pub fn new() -> Self {
         Self {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -5,12 +5,13 @@ pub mod execution;
 pub mod heap;
 pub mod opcodes;
 pub mod value;
+#[allow(clippy::module_inception)]
 pub mod vm;
 
 pub use crate::vm::error::VmError;
 pub use crate::vm::execution::ExecutionContext;
 pub use crate::vm::heap::{Heap, HeapObject};
-pub use crate::vm::opcodes::OpCode;
+pub use crate::vm::opcodes::{Bytecode, ExecutionState, OpCode};
 pub use crate::vm::value::Value;
 pub use crate::vm::vm::VM;
 

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -1,11 +1,233 @@
 // src/vm/opcodes.rs
 
+use std::convert::TryFrom;
+
 use crate::vm::error::VmError;
 use crate::vm::execution::ExecutionContext;
 use crate::vm::heap::{Heap, HeapObject};
 use crate::vm::value::Value;
 use crate::vm::vm::VM;
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::{error::TrySendError, Sender};
+
+const OPERAND_WIDTH: usize = std::mem::size_of::<u32>();
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Bytecode {
+    code: Vec<u8>,
+    constants: Vec<Value>,
+    offsets: Vec<usize>,
+}
+
+impl Bytecode {
+    pub fn new(code: Vec<u8>, constants: Vec<Value>, offsets: Vec<usize>) -> Self {
+        Self {
+            code,
+            constants,
+            offsets,
+        }
+    }
+
+    pub fn from_opcodes(opcodes: Vec<OpCode>) -> Self {
+        let mut code = Vec::with_capacity(opcodes.len());
+        let mut constants = Vec::new();
+        let mut offsets = Vec::with_capacity(opcodes.len());
+
+        for opcode in opcodes {
+            offsets.push(code.len());
+            opcode.encode(&mut code, &mut constants);
+        }
+
+        Self::new(code, constants, offsets)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.offsets.is_empty()
+    }
+
+    pub fn instruction_len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.code
+    }
+
+    pub fn constants(&self) -> &[Value] {
+        &self.constants
+    }
+
+    pub fn patch_instruction(&mut self, index: usize, opcode: OpCode) -> Result<(), VmError> {
+        if index >= self.offsets.len() {
+            return Err(VmError::ExecutionOutOfBounds);
+        }
+        let mut opcodes = self.to_opcodes()?;
+        opcodes[index] = opcode;
+        *self = Self::from_opcodes(opcodes);
+        Ok(())
+    }
+
+    pub fn decode_at(&self, instruction_index: usize) -> Result<OpCode, VmError> {
+        let Some(&offset) = self.offsets.get(instruction_index) else {
+            return Err(VmError::ExecutionOutOfBounds);
+        };
+        let tag = *self.code.get(offset).ok_or(VmError::ExecutionOutOfBounds)?;
+        let kind = DenseOp::try_from(tag)?;
+        let operand = if kind.has_operand() {
+            let start = offset + 1;
+            let end = start + OPERAND_WIDTH;
+            let bytes: [u8; OPERAND_WIDTH] = self
+                .code
+                .get(start..end)
+                .ok_or(VmError::ExecutionOutOfBounds)?
+                .try_into()
+                .map_err(|_| VmError::ExecutionOutOfBounds)?;
+            Some(u32::from_le_bytes(bytes) as usize)
+        } else {
+            None
+        };
+
+        match kind {
+            DenseOp::StoreVar => Ok(OpCode::StoreVar(operand.unwrap())),
+            DenseOp::LoadVar => Ok(OpCode::LoadVar(operand.unwrap())),
+            DenseOp::PushConst => {
+                let index = operand.unwrap();
+                let value = *self
+                    .constants
+                    .get(index)
+                    .ok_or(VmError::ExecutionOutOfBounds)?;
+                Ok(OpCode::PushConst(value))
+            }
+            DenseOp::Pop => Ok(OpCode::Pop),
+            DenseOp::Dup => Ok(OpCode::Dup),
+            DenseOp::Swap => Ok(OpCode::Swap),
+            DenseOp::Add => Ok(OpCode::Add),
+            DenseOp::Sub => Ok(OpCode::Sub),
+            DenseOp::Mul => Ok(OpCode::Mul),
+            DenseOp::Div => Ok(OpCode::Div),
+            DenseOp::Mod => Ok(OpCode::Mod),
+            DenseOp::Neg => Ok(OpCode::Neg),
+            DenseOp::Exp => Ok(OpCode::Exp),
+            DenseOp::Jump => Ok(OpCode::Jump(operand.unwrap())),
+            DenseOp::JumpIfFalse => Ok(OpCode::JumpIfFalse(operand.unwrap())),
+            DenseOp::Call => Ok(OpCode::Call(operand.unwrap())),
+            DenseOp::Return => Ok(OpCode::Return),
+            DenseOp::SpawnActor => Ok(OpCode::SpawnActor(operand.unwrap())),
+            DenseOp::SendMessage => Ok(OpCode::SendMessage),
+            DenseOp::ReceiveMessage => Ok(OpCode::ReceiveMessage),
+            DenseOp::SpawnSupervisor => Ok(OpCode::SpawnSupervisor(operand.unwrap())),
+            DenseOp::SetStrategy => Ok(OpCode::SetStrategy(operand.unwrap())),
+            DenseOp::RestartChild => Ok(OpCode::RestartChild(operand.unwrap())),
+        }
+    }
+
+    pub fn to_opcodes(&self) -> Result<Vec<OpCode>, VmError> {
+        (0..self.instruction_len())
+            .map(|index| self.decode_at(index))
+            .collect()
+    }
+}
+
+impl From<Vec<OpCode>> for Bytecode {
+    fn from(opcodes: Vec<OpCode>) -> Self {
+        Self::from_opcodes(opcodes)
+    }
+}
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
+enum DenseOp {
+    StoreVar = 0x01,
+    LoadVar = 0x02,
+    PushConst = 0x03,
+    Pop = 0x04,
+    Dup = 0x05,
+    Swap = 0x06,
+    Add = 0x10,
+    Sub = 0x11,
+    Mul = 0x12,
+    Div = 0x13,
+    Mod = 0x14,
+    Neg = 0x15,
+    Exp = 0x16,
+    Jump = 0x20,
+    JumpIfFalse = 0x21,
+    Call = 0x22,
+    Return = 0x23,
+    SpawnActor = 0x30,
+    SendMessage = 0x31,
+    ReceiveMessage = 0x32,
+    SpawnSupervisor = 0x40,
+    SetStrategy = 0x41,
+    RestartChild = 0x42,
+}
+
+impl DenseOp {
+    fn has_operand(self) -> bool {
+        matches!(
+            self,
+            DenseOp::StoreVar
+                | DenseOp::LoadVar
+                | DenseOp::PushConst
+                | DenseOp::Jump
+                | DenseOp::JumpIfFalse
+                | DenseOp::Call
+                | DenseOp::SpawnActor
+                | DenseOp::SpawnSupervisor
+                | DenseOp::SetStrategy
+                | DenseOp::RestartChild
+        )
+    }
+}
+
+impl TryFrom<u8> for DenseOp {
+    type Error = VmError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(DenseOp::StoreVar),
+            0x02 => Ok(DenseOp::LoadVar),
+            0x03 => Ok(DenseOp::PushConst),
+            0x04 => Ok(DenseOp::Pop),
+            0x05 => Ok(DenseOp::Dup),
+            0x06 => Ok(DenseOp::Swap),
+            0x10 => Ok(DenseOp::Add),
+            0x11 => Ok(DenseOp::Sub),
+            0x12 => Ok(DenseOp::Mul),
+            0x13 => Ok(DenseOp::Div),
+            0x14 => Ok(DenseOp::Mod),
+            0x15 => Ok(DenseOp::Neg),
+            0x16 => Ok(DenseOp::Exp),
+            0x20 => Ok(DenseOp::Jump),
+            0x21 => Ok(DenseOp::JumpIfFalse),
+            0x22 => Ok(DenseOp::Call),
+            0x23 => Ok(DenseOp::Return),
+            0x30 => Ok(DenseOp::SpawnActor),
+            0x31 => Ok(DenseOp::SendMessage),
+            0x32 => Ok(DenseOp::ReceiveMessage),
+            0x40 => Ok(DenseOp::SpawnSupervisor),
+            0x41 => Ok(DenseOp::SetStrategy),
+            0x42 => Ok(DenseOp::RestartChild),
+            _ => Err(VmError::ExecutionOutOfBounds),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ExecutionState {
+    Running,
+    Yield(BlockingOperation),
+    Halted,
+}
+
+#[derive(Debug)]
+pub enum BlockingOperation {
+    ReceiveMessage,
+    SendMessage {
+        sender: Sender<Value>,
+        message: Value,
+        actor_address: usize,
+    },
+}
 
 fn unary_op<F>(execution: &mut ExecutionContext, heap: &mut Heap, f: F) -> Result<(), VmError>
 where
@@ -50,7 +272,7 @@ fn decrement_reference(heap: &mut Heap, address: usize) -> Result<(), VmError> {
     }
 }
 
-fn push_value(
+pub(crate) fn push_value(
     execution: &mut ExecutionContext,
     heap: &mut Heap,
     value: Value,
@@ -62,7 +284,10 @@ fn push_value(
     Ok(())
 }
 
-fn pop_value(execution: &mut ExecutionContext, heap: &mut Heap) -> Result<Value, VmError> {
+pub(crate) fn pop_value(
+    execution: &mut ExecutionContext,
+    heap: &mut Heap,
+) -> Result<Value, VmError> {
     if let Some(value) = execution.stack.pop() {
         if let Value::Reference(address) = value {
             decrement_reference(heap, address)?;
@@ -73,19 +298,14 @@ fn pop_value(execution: &mut ExecutionContext, heap: &mut Heap) -> Result<Value,
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum OpCode {
-    // Variables
     StoreVar(usize),
     LoadVar(usize),
-
-    // Stack
     PushConst(Value),
     Pop,
     Dup,
     Swap,
-
-    // Arithmetic
     Add,
     Sub,
     Mul,
@@ -93,51 +313,80 @@ pub enum OpCode {
     Mod,
     Neg,
     Exp,
-
-    // Control Flow
     Jump(usize),
     JumpIfFalse(usize),
     Call(usize),
     Return,
-
-    // Actors
     SpawnActor(usize),
     SendMessage,
     ReceiveMessage,
-
-    // Supervisor
     SpawnSupervisor(usize),
     SetStrategy(usize),
     RestartChild(usize),
 }
 
 impl OpCode {
-    pub async fn execute(
-        &self,
+    fn encode(self, code: &mut Vec<u8>, constants: &mut Vec<Value>) {
+        let (dense, operand) = match self {
+            OpCode::StoreVar(index) => (DenseOp::StoreVar, Some(index)),
+            OpCode::LoadVar(index) => (DenseOp::LoadVar, Some(index)),
+            OpCode::PushConst(value) => {
+                let index = constants.len();
+                constants.push(value);
+                (DenseOp::PushConst, Some(index))
+            }
+            OpCode::Pop => (DenseOp::Pop, None),
+            OpCode::Dup => (DenseOp::Dup, None),
+            OpCode::Swap => (DenseOp::Swap, None),
+            OpCode::Add => (DenseOp::Add, None),
+            OpCode::Sub => (DenseOp::Sub, None),
+            OpCode::Mul => (DenseOp::Mul, None),
+            OpCode::Div => (DenseOp::Div, None),
+            OpCode::Mod => (DenseOp::Mod, None),
+            OpCode::Neg => (DenseOp::Neg, None),
+            OpCode::Exp => (DenseOp::Exp, None),
+            OpCode::Jump(target) => (DenseOp::Jump, Some(target)),
+            OpCode::JumpIfFalse(target) => (DenseOp::JumpIfFalse, Some(target)),
+            OpCode::Call(addr) => (DenseOp::Call, Some(addr)),
+            OpCode::Return => (DenseOp::Return, None),
+            OpCode::SpawnActor(addr) => (DenseOp::SpawnActor, Some(addr)),
+            OpCode::SendMessage => (DenseOp::SendMessage, None),
+            OpCode::ReceiveMessage => (DenseOp::ReceiveMessage, None),
+            OpCode::SpawnSupervisor(addr) => (DenseOp::SpawnSupervisor, Some(addr)),
+            OpCode::SetStrategy(strategy) => (DenseOp::SetStrategy, Some(strategy)),
+            OpCode::RestartChild(child) => (DenseOp::RestartChild, Some(child)),
+        };
+
+        code.push(dense as u8);
+        if let Some(operand) = operand {
+            code.extend_from_slice(&(operand as u32).to_le_bytes());
+        }
+    }
+
+    pub fn execute(
+        self,
         execution: &mut ExecutionContext,
         heap: &mut Heap,
-        mailbox: &mut Receiver<Value>,
-    ) -> Result<(), VmError> {
+    ) -> Result<ExecutionState, VmError> {
         match self {
-            OpCode::Add => binary_op(execution, heap, |a, b| a.add(b)),
-            OpCode::Sub => binary_op(execution, heap, |a, b| a.sub(b)),
-            OpCode::Mul => binary_op(execution, heap, |a, b| a.mul(b)),
-            OpCode::Div => binary_op(execution, heap, |a, b| a.div(b)),
+            OpCode::Add => binary_op(execution, heap, |a, b| a.add(b))?,
+            OpCode::Sub => binary_op(execution, heap, |a, b| a.sub(b))?,
+            OpCode::Mul => binary_op(execution, heap, |a, b| a.mul(b))?,
+            OpCode::Div => binary_op(execution, heap, |a, b| a.div(b))?,
             OpCode::Neg => unary_op(execution, heap, |a| match a {
                 Value::Integer(i) => Ok(Value::Integer(-i)),
                 Value::Float(f) => Ok(Value::Float(-f)),
                 _ => Err(VmError::TypeMismatch("Neg")),
-            }),
-            OpCode::PushConst(v) => push_value(execution, heap, *v),
+            })?,
+            OpCode::PushConst(v) => push_value(execution, heap, v)?,
             OpCode::Pop => {
                 pop_value(execution, heap)?;
-                Ok(())
             }
             OpCode::Dup => {
                 if let Some(&value) = execution.stack.last() {
-                    push_value(execution, heap, value)
+                    push_value(execution, heap, value)?;
                 } else {
-                    Err(VmError::StackUnderflow)
+                    return Err(VmError::StackUnderflow);
                 }
             }
             OpCode::Swap => {
@@ -146,28 +395,21 @@ impl OpCode {
                 }
                 let len = execution.stack.len();
                 execution.stack.swap(len - 1, len - 2);
-                Ok(())
             }
             OpCode::StoreVar(index) => {
                 let value = pop_value(execution, heap)?;
-
-                if let Some(existing) = execution.locals.insert(*index, value) {
-                    if let Value::Reference(address) = existing {
-                        decrement_reference(heap, address)?;
-                    }
+                if let Some(Value::Reference(address)) = execution.locals.insert(index, value) {
+                    decrement_reference(heap, address)?;
                 }
-
                 if let Value::Reference(address) = value {
                     increment_reference(heap, address)?;
                 }
-
-                Ok(())
             }
             OpCode::LoadVar(index) => {
-                if let Some(value) = execution.locals.get(index) {
-                    push_value(execution, heap, *value)
+                if let Some(value) = execution.locals.get(&index) {
+                    push_value(execution, heap, *value)?;
                 } else {
-                    Err(VmError::VariableNotFound(*index))
+                    return Err(VmError::VariableNotFound(index));
                 }
             }
             OpCode::Mod => binary_op(execution, heap, |a, b| match (a, b) {
@@ -179,7 +421,7 @@ impl OpCode {
                     }
                 }
                 _ => Err(VmError::TypeMismatch("Mod")),
-            }),
+            })?,
             OpCode::Exp => binary_op(execution, heap, |a, b| match (a, b) {
                 (Value::Integer(x), Value::Integer(y)) => {
                     if y < 0 {
@@ -190,95 +432,61 @@ impl OpCode {
                 }
                 (Value::Float(x), Value::Float(y)) => Ok(Value::Float(x.powf(y))),
                 _ => Err(VmError::TypeMismatch("Exp")),
-            }),
+            })?,
             OpCode::Jump(target) => {
-                if *target > execution.bytecode.len() {
-                    log::error!(
-                        "Jump target {} out of bounds (bytecode length {})",
-                        target,
-                        execution.bytecode.len()
-                    );
-                    return Err(VmError::ExecutionOutOfBounds);
-                }
-
-                execution.ip = *target;
-                Ok(())
+                validate_target(execution, target, true)?;
+                execution.ip = target;
             }
-
             OpCode::JumpIfFalse(target) => {
                 let value = pop_value(execution, heap)?;
                 match value {
                     Value::Boolean(false) => {
-                        if *target > execution.bytecode.len() {
-                            log::error!(
-                                "JumpIfFalse target {} out of bounds (bytecode length {})",
-                                target,
-                                execution.bytecode.len()
-                            );
-                            return Err(VmError::ExecutionOutOfBounds);
-                        }
-                        execution.ip = *target;
-                        Ok(())
+                        validate_target(execution, target, true)?;
+                        execution.ip = target;
                     }
-                    Value::Boolean(true) => Ok(()),
-                    _ => Err(VmError::TypeMismatch("JumpIfFalse")),
+                    Value::Boolean(true) => {}
+                    _ => return Err(VmError::TypeMismatch("JumpIfFalse")),
                 }
             }
             OpCode::Call(addr) => {
-                if *addr >= execution.bytecode.len() {
-                    log::error!(
-                        "Call target {} out of bounds (bytecode length {})",
-                        addr,
-                        execution.bytecode.len()
-                    );
-                    return Err(VmError::ExecutionOutOfBounds);
-                }
-
+                validate_target(execution, addr, false)?;
                 execution.call_stack.push(execution.ip);
-                execution.ip = *addr;
-                Ok(())
+                execution.ip = addr;
             }
             OpCode::Return => {
                 if let Some(return_addr) = execution.call_stack.pop() {
                     execution.ip = return_addr;
-                    Ok(())
                 } else {
-                    execution.ip = execution.bytecode.len();
-                    Ok(())
+                    execution.ip = execution.bytecode.instruction_len();
+                    return Ok(ExecutionState::Halted);
                 }
             }
             OpCode::ReceiveMessage => {
-                if let Some(message) = mailbox.recv().await {
-                    log::info!("Received message: {:?}", message);
-                    if let Value::Reference(address) = message {
-                        decrement_reference(heap, address)?;
+                return match execution
+                    .pending_receive
+                    .take()
+                    .or_else(|| execution.mailbox.try_recv().ok())
+                {
+                    Some(message) => {
+                        log::info!("Received message: {:?}", message);
+                        if let Value::Reference(address) = message {
+                            decrement_reference(heap, address)?;
+                        }
+                        push_value(execution, heap, message)?;
+                        Ok(ExecutionState::Running)
                     }
-                    push_value(execution, heap, message)
-                } else {
-                    log::warn!("Mailbox is empty or closed");
-                    Err(VmError::MailboxEmpty)
-                }
+                    None => Ok(ExecutionState::Yield(BlockingOperation::ReceiveMessage)),
+                };
             }
-
             OpCode::SpawnActor(addr) => {
+                validate_target(execution, addr, false)?;
                 let bytecode = execution.bytecode.clone();
                 let (mut vm, tx) = VM::new(bytecode, None);
-                if *addr >= execution.bytecode.len() {
-                    log::error!(
-                        "SpawnActor target {} out of bounds (bytecode length {})",
-                        addr,
-                        execution.bytecode.len()
-                    );
-                    return Err(VmError::ExecutionOutOfBounds);
-                }
-                vm.set_ip(*addr);
+                vm.set_ip(addr);
                 let address = heap.allocate(HeapObject::Actor(vm, tx, 0));
-                push_value(execution, heap, Value::Reference(address))
+                push_value(execution, heap, Value::Reference(address))?;
             }
             OpCode::SendMessage => {
-                // SendMessage has stack-stable behavior for actor references:
-                // the actor reference is present on the stack after the opcode
-                // finishes, regardless of success or failure.
                 let actor_ref = pop_value(execution, heap)?;
                 let message = pop_value(execution, heap)?;
                 if let Value::Reference(address) = actor_ref {
@@ -289,68 +497,84 @@ impl OpCode {
                     if let Value::Reference(message_address) = message {
                         increment_reference(heap, message_address)?;
                     }
-                    match sender.send(message).await {
-                        Ok(()) => push_value(execution, heap, Value::Reference(address)),
-                        Err(err) => {
-                            let error = err.to_string();
-                            let failed_message = err.0;
+                    return match sender.try_send(message) {
+                        Ok(()) => {
                             push_value(execution, heap, Value::Reference(address))?;
-                            // Keep the recovered message alive so that callers can
-                            // safely inspect or resend it from the returned error.
-                            // The send attempt already incremented the reference
-                            // count to transfer ownership to the channel, so we
-                            // intentionally skip the corresponding decrement here.
+                            Ok(ExecutionState::Running)
+                        }
+                        Err(TrySendError::Full(message)) => {
+                            Ok(ExecutionState::Yield(BlockingOperation::SendMessage {
+                                sender,
+                                message,
+                                actor_address: address,
+                            }))
+                        }
+                        Err(TrySendError::Closed(failed_message)) => {
+                            push_value(execution, heap, Value::Reference(address))?;
                             Err(VmError::ChannelSend {
-                                error,
+                                error: "channel closed".to_string(),
                                 value: failed_message,
                             })
                         }
-                    }
+                    };
                 } else {
-                    Err(VmError::InvalidReference)
+                    return Err(VmError::InvalidReference);
                 }
             }
             OpCode::SpawnSupervisor(addr) => {
+                validate_target(execution, addr, false)?;
                 let bytecode = execution.bytecode.clone();
                 let (mut vm, tx) = VM::new(bytecode, None);
-                if *addr >= execution.bytecode.len() {
-                    log::error!(
-                        "SpawnSupervisor target {} out of bounds (bytecode length {})",
-                        addr,
-                        execution.bytecode.len()
-                    );
-                    return Err(VmError::ExecutionOutOfBounds);
-                }
-                vm.set_ip(*addr);
+                vm.set_ip(addr);
                 let address = heap.allocate(HeapObject::Supervisor(vm, tx, 0));
-                push_value(execution, heap, Value::Reference(address))
+                push_value(execution, heap, Value::Reference(address))?;
             }
             OpCode::SetStrategy(strategy) => {
                 let sup_ref = pop_value(execution, heap)?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _, _)) = heap.get_mut(addr) {
-                        vm.set_strategy(*strategy);
+                        vm.set_strategy(strategy);
                     } else {
                         return Err(VmError::InvalidReference);
                     }
-                    push_value(execution, heap, Value::Reference(addr))
+                    push_value(execution, heap, Value::Reference(addr))?;
                 } else {
-                    Err(VmError::InvalidReference)
+                    return Err(VmError::InvalidReference);
                 }
             }
             OpCode::RestartChild(child) => {
                 let sup_ref = pop_value(execution, heap)?;
                 if let Value::Reference(addr) = sup_ref {
                     if let Some(HeapObject::Supervisor(vm, _, _)) = heap.get_mut(addr) {
-                        vm.restart_child(*child);
+                        vm.restart_child(child);
                     } else {
                         return Err(VmError::InvalidReference);
                     }
-                    push_value(execution, heap, Value::Reference(addr))
+                    push_value(execution, heap, Value::Reference(addr))?;
                 } else {
-                    Err(VmError::InvalidReference)
+                    return Err(VmError::InvalidReference);
                 }
             }
         }
+
+        Ok(ExecutionState::Running)
+    }
+}
+
+fn validate_target(
+    execution: &ExecutionContext,
+    target: usize,
+    allow_end: bool,
+) -> Result<(), VmError> {
+    let len = execution.bytecode.instruction_len();
+    if target > len || (!allow_end && target == len) {
+        log::error!(
+            "Instruction target {} out of bounds (instruction length {})",
+            target,
+            len
+        );
+        Err(VmError::ExecutionOutOfBounds)
+    } else {
+        Ok(())
     }
 }

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -12,6 +12,7 @@ pub enum Value {
     Null,
 }
 
+#[allow(clippy::should_implement_trait)]
 impl Value {
     pub fn add(self, other: Value) -> Result<Value, VmError> {
         match (self, other) {

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -3,32 +3,42 @@
 use crate::vm::error::VmError;
 use crate::vm::execution::ExecutionContext;
 use crate::vm::heap::{Heap, HeapObject};
-use crate::vm::opcodes::OpCode;
+use crate::vm::opcodes::{push_value, BlockingOperation, Bytecode, ExecutionState};
 use crate::vm::value::Value;
 
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 #[derive(Debug)]
 pub struct VM {
-    execution: ExecutionContext,
-    heap: Heap,
-    pub mailbox: Receiver<Value>,
+    pub execution: ExecutionContext,
+    pub heap: Heap,
     _supervisor: Option<Sender<usize>>,
 }
 
 impl VM {
-    pub fn new(bytecode: Vec<OpCode>, supervisor: Option<Sender<usize>>) -> (Self, Sender<Value>) {
+    pub fn new<B>(bytecode: B, supervisor: Option<Sender<usize>>) -> (Self, Sender<Value>)
+    where
+        B: Into<Bytecode>,
+    {
         let (tx, rx) = mpsc::channel(100);
-        log::info!("Initializing VM with {} opcodes", bytecode.len());
+        let bytecode = bytecode.into();
+        log::info!(
+            "Initializing VM with {} instructions ({} byte bytecode)",
+            bytecode.instruction_len(),
+            bytecode.bytes().len()
+        );
         (
             VM {
-                execution: ExecutionContext::new(bytecode),
+                execution: ExecutionContext::from_bytecode(bytecode, rx),
                 heap: Heap::new(),
-                mailbox: rx,
                 _supervisor: supervisor,
             },
             tx,
         )
+    }
+
+    pub fn mailbox_mut(&mut self) -> &mut Receiver<Value> {
+        &mut self.execution.mailbox
     }
 
     pub fn pop_stack(&mut self) -> Result<Value, VmError> {
@@ -76,14 +86,64 @@ impl VM {
             return Err(VmError::NoBytecode);
         }
 
-        while self.execution.ip < self.execution.bytecode.len() {
-            if let Err(e) = self.execution.step(&mut self.heap, &mut self.mailbox).await {
-                log::error!("Execution error at ip {}: {}", self.execution.ip, e);
-                return Err(e);
+        loop {
+            match self.execution.step(&mut self.heap) {
+                Ok(ExecutionState::Running) => {}
+                Ok(ExecutionState::Halted) => {
+                    log::info!("VM execution completed successfully");
+                    return Ok(());
+                }
+                Ok(ExecutionState::Yield(operation)) => {
+                    self.await_blocking_operation(operation).await?
+                }
+                Err(e) => {
+                    log::error!("Execution error at ip {}: {}", self.execution.ip, e);
+                    return Err(e);
+                }
             }
         }
-        log::info!("VM execution completed successfully");
-        Ok(())
+    }
+
+    async fn await_blocking_operation(
+        &mut self,
+        operation: BlockingOperation,
+    ) -> Result<(), VmError> {
+        match operation {
+            BlockingOperation::ReceiveMessage => {
+                if let Some(message) = self.execution.mailbox.recv().await {
+                    self.execution.pending_receive = Some(message);
+                    self.execution.ip = self.execution.ip.saturating_sub(1);
+                    Ok(())
+                } else {
+                    log::warn!("Mailbox is empty or closed");
+                    Err(VmError::MailboxEmpty)
+                }
+            }
+            BlockingOperation::SendMessage {
+                sender,
+                message,
+                actor_address,
+            } => match sender.send(message).await {
+                Ok(()) => push_value(
+                    &mut self.execution,
+                    &mut self.heap,
+                    Value::Reference(actor_address),
+                ),
+                Err(err) => {
+                    let error = err.to_string();
+                    let failed_message = err.0;
+                    push_value(
+                        &mut self.execution,
+                        &mut self.heap,
+                        Value::Reference(actor_address),
+                    )?;
+                    Err(VmError::ChannelSend {
+                        error,
+                        value: failed_message,
+                    })
+                }
+            },
+        }
     }
 
     /// Expose a reference to the execution stack for testing or inspection.
@@ -103,6 +163,7 @@ impl VM {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::opcodes::OpCode;
     use crate::vm::value::Value;
 
     #[tokio::test]
@@ -149,44 +210,50 @@ mod tests {
             OpCode::Add,
         ];
 
-        let mut ctx = ExecutionContext::new(code);
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let mut ctx = ExecutionContext::with_mailbox(code, rx);
         let mut heap = Heap::new();
-        let (_tx, mut rx) = tokio::sync::mpsc::channel(1);
 
-        ctx.step(&mut heap, &mut rx).await.unwrap();
+        ctx.step(&mut heap).unwrap();
         assert_eq!(ctx.ip, 1);
 
-        ctx.step(&mut heap, &mut rx).await.unwrap();
+        ctx.step(&mut heap).unwrap();
         assert_eq!(ctx.ip, 2);
 
-        ctx.step(&mut heap, &mut rx).await.unwrap();
+        ctx.step(&mut heap).unwrap();
         assert_eq!(ctx.ip, 3);
     }
 
     #[tokio::test]
     async fn test_jump_and_call_modify_ip() {
         // Test Jump
-        let mut ctx = ExecutionContext::new(vec![
-            OpCode::Jump(2),
-            OpCode::PushConst(Value::Integer(0)),
-            OpCode::PushConst(Value::Integer(1)),
-        ]);
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let mut ctx = ExecutionContext::with_mailbox(
+            vec![
+                OpCode::Jump(2),
+                OpCode::PushConst(Value::Integer(0)),
+                OpCode::PushConst(Value::Integer(1)),
+            ],
+            rx,
+        );
         let mut heap = Heap::new();
-        let (_tx, mut rx) = tokio::sync::mpsc::channel(1);
 
-        ctx.step(&mut heap, &mut rx).await.unwrap();
+        ctx.step(&mut heap).unwrap();
         assert_eq!(ctx.ip, 2);
 
         // Test Call
-        let mut ctx = ExecutionContext::new(vec![
-            OpCode::Call(2),
-            OpCode::PushConst(Value::Integer(99)),
-            OpCode::Return,
-        ]);
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let mut ctx = ExecutionContext::with_mailbox(
+            vec![
+                OpCode::Call(2),
+                OpCode::PushConst(Value::Integer(99)),
+                OpCode::Return,
+            ],
+            rx,
+        );
         let mut heap = Heap::new();
-        let (_tx, mut rx) = tokio::sync::mpsc::channel(1);
 
-        ctx.step(&mut heap, &mut rx).await.unwrap();
+        ctx.step(&mut heap).unwrap();
         assert_eq!(ctx.ip, 2);
         assert_eq!(ctx.call_stack, vec![1]);
     }
@@ -243,17 +310,14 @@ mod tests {
         let (mut vm, _tx) = VM::new(code, None);
 
         let message_addr = vm.heap.allocate(HeapObject::Array(vec![], 0));
-        vm.execution.bytecode[0] = OpCode::PushConst(Value::Reference(message_addr));
+        vm.execution
+            .bytecode
+            .patch_instruction(0, OpCode::PushConst(Value::Reference(message_addr)))
+            .unwrap();
 
         // Execute PushConst and SpawnActor
-        vm.execution
-            .step(&mut vm.heap, &mut vm.mailbox)
-            .await
-            .unwrap();
-        vm.execution
-            .step(&mut vm.heap, &mut vm.mailbox)
-            .await
-            .unwrap();
+        vm.execution.step(&mut vm.heap).unwrap();
+        vm.execution.step(&mut vm.heap).unwrap();
 
         // Close actor mailbox to force send failure
         let actor_addr = match vm.execution.stack.last() {
@@ -261,13 +325,13 @@ mod tests {
             other => panic!("Expected actor reference, got {:?}", other),
         };
         if let Some(HeapObject::Actor(actor_vm, _, _)) = vm.heap.get_mut(actor_addr) {
-            actor_vm.mailbox.close();
+            actor_vm.mailbox_mut().close();
         } else {
             panic!("Expected HeapObject::Actor");
         }
 
         // SendMessage should now fail
-        let result = vm.execution.step(&mut vm.heap, &mut vm.mailbox).await;
+        let result = vm.execution.step(&mut vm.heap);
 
         match result {
             Err(VmError::ChannelSend { value, .. }) => {
@@ -286,7 +350,10 @@ mod tests {
         }
 
         if let Some(HeapObject::Actor(_, _, rc)) = vm.heap.get(actor_addr) {
-            assert_eq!(*rc, 0, "actor reference count should be 0 after failure");
+            assert_eq!(
+                *rc, 1,
+                "actor reference count should stay on stack after failure"
+            );
         } else {
             panic!("Expected HeapObject::Actor");
         }

--- a/tests/bytecode.rs
+++ b/tests/bytecode.rs
@@ -1,0 +1,23 @@
+use raft::vm::{Bytecode, OpCode, Value};
+
+#[test]
+fn bytecode_encodes_simple_opcodes_as_single_bytes() {
+    let bytecode = Bytecode::from_opcodes(vec![OpCode::Add, OpCode::Dup, OpCode::Pop]);
+
+    assert_eq!(bytecode.instruction_len(), 3);
+    assert_eq!(bytecode.bytes().len(), 3);
+    assert!(bytecode.constants().is_empty());
+}
+
+#[test]
+fn push_const_uses_constant_pool_operand_instead_of_inline_value() {
+    let bytecode = Bytecode::from_opcodes(vec![OpCode::PushConst(Value::Integer(42))]);
+
+    assert_eq!(bytecode.instruction_len(), 1);
+    assert_eq!(bytecode.bytes().len(), 5);
+    assert_eq!(bytecode.constants(), &[Value::Integer(42)]);
+    assert_eq!(
+        bytecode.decode_at(0).unwrap(),
+        OpCode::PushConst(Value::Integer(42))
+    );
+}

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -36,11 +36,11 @@ fn compile_control_flow_tokens() {
 
 #[test]
 fn compile_float_tokens() {
-    let source = "3.14 2.0 +";
+    let source = "3.5 2.0 +";
     let bytecode = Compiler::compile(source).unwrap();
     assert_eq!(bytecode.len(), 3);
     assert!(
-        matches!(bytecode[0], OpCode::PushConst(Value::Float(f)) if (f - 3.14).abs() < f64::EPSILON)
+        matches!(bytecode[0], OpCode::PushConst(Value::Float(f)) if (f - 3.5).abs() < f64::EPSILON)
     );
     assert!(
         matches!(bytecode[1], OpCode::PushConst(Value::Float(f)) if (f - 2.0).abs() < f64::EPSILON)

--- a/tests/jump_if_false.rs
+++ b/tests/jump_if_false.rs
@@ -3,17 +3,13 @@ use raft::vm::execution::ExecutionContext;
 use raft::vm::heap::{Heap, HeapObject};
 use raft::vm::opcodes::OpCode;
 use raft::vm::value::Value;
-use tokio::sync::mpsc::channel;
 
 #[tokio::test]
 async fn jump_if_false_errors_on_non_boolean() {
     let mut ctx = ExecutionContext::new(vec![]);
     ctx.stack.push(Value::Integer(42));
     let mut heap = Heap::new();
-    let (_tx, mut rx) = channel(1);
-    let result = OpCode::JumpIfFalse(0)
-        .execute(&mut ctx, &mut heap, &mut rx)
-        .await;
+    let result = OpCode::JumpIfFalse(0).execute(&mut ctx, &mut heap);
     assert!(matches!(result, Err(VmError::TypeMismatch("JumpIfFalse"))));
 }
 
@@ -21,10 +17,7 @@ async fn jump_if_false_errors_on_non_boolean() {
 async fn jump_if_false_errors_on_empty_stack() {
     let mut ctx = ExecutionContext::new(vec![]);
     let mut heap = Heap::new();
-    let (_tx, mut rx) = channel(1);
-    let result = OpCode::JumpIfFalse(0)
-        .execute(&mut ctx, &mut heap, &mut rx)
-        .await;
+    let result = OpCode::JumpIfFalse(0).execute(&mut ctx, &mut heap);
     assert!(matches!(result, Err(VmError::StackUnderflow)));
 }
 
@@ -41,11 +34,9 @@ async fn jump_if_false_skips_jump_when_true() {
     ctx.stack.push(Value::Boolean(true));
     ctx.ip = 7;
     let mut heap = Heap::new();
-    let (_tx, mut rx) = channel(1);
 
     OpCode::JumpIfFalse(99)
-        .execute(&mut ctx, &mut heap, &mut rx)
-        .await
+        .execute(&mut ctx, &mut heap)
         .unwrap();
 
     assert_eq!(ctx.ip, 7);
@@ -54,14 +45,10 @@ async fn jump_if_false_skips_jump_when_true() {
 
 #[tokio::test]
 async fn jump_if_false_drops_reference_on_type_mismatch() {
-    let mut ctx = ExecutionContext::new(vec![]);
+    let mut ctx = ExecutionContext::new(vec![OpCode::Return]);
     let mut heap = Heap::new();
-    let (_tx, mut rx) = channel(1);
 
-    OpCode::SpawnActor(0)
-        .execute(&mut ctx, &mut heap, &mut rx)
-        .await
-        .unwrap();
+    OpCode::SpawnActor(0).execute(&mut ctx, &mut heap).unwrap();
 
     let address = match ctx.stack.last().copied() {
         Some(Value::Reference(addr)) => addr,
@@ -70,9 +57,7 @@ async fn jump_if_false_drops_reference_on_type_mismatch() {
 
     assert_eq!(actor_ref_count(&heap, address), 1);
 
-    let result = OpCode::JumpIfFalse(0)
-        .execute(&mut ctx, &mut heap, &mut rx)
-        .await;
+    let result = OpCode::JumpIfFalse(0).execute(&mut ctx, &mut heap);
 
     assert!(matches!(result, Err(VmError::TypeMismatch("JumpIfFalse"))));
     assert!(ctx.stack.is_empty());

--- a/tests/reference_counts.rs
+++ b/tests/reference_counts.rs
@@ -16,11 +16,9 @@ fn actor_ref_count(heap: &Heap, address: usize) -> usize {
 async fn actor_reference_lifecycle_on_stack() {
     let mut execution = ExecutionContext::new(vec![OpCode::Return]);
     let mut heap = Heap::new();
-    let (_tx, mut mailbox) = channel(1);
 
     OpCode::SpawnActor(0)
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .unwrap();
 
     let address = match execution.stack.last().copied() {
@@ -30,22 +28,13 @@ async fn actor_reference_lifecycle_on_stack() {
 
     assert_eq!(actor_ref_count(&heap, address), 1);
 
-    OpCode::Dup
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap();
+    OpCode::Dup.execute(&mut execution, &mut heap).unwrap();
     assert_eq!(actor_ref_count(&heap, address), 2);
 
-    OpCode::Pop
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap();
+    OpCode::Pop.execute(&mut execution, &mut heap).unwrap();
     assert_eq!(actor_ref_count(&heap, address), 1);
 
-    OpCode::Pop
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap();
+    OpCode::Pop.execute(&mut execution, &mut heap).unwrap();
     assert_eq!(actor_ref_count(&heap, address), 0);
 
     heap.collect_garbage();
@@ -54,14 +43,13 @@ async fn actor_reference_lifecycle_on_stack() {
 
 #[tokio::test]
 async fn send_and_receive_message_updates_reference_counts() {
-    let mut execution = ExecutionContext::new(vec![OpCode::Return]);
+    let (tx, rx) = channel(1);
+    let mut execution = ExecutionContext::with_mailbox(vec![OpCode::Return], rx);
     let mut heap = Heap::new();
-    let (tx, mut mailbox) = channel(1);
 
     // Spawn target actor (A) and message actor (B)
     OpCode::SpawnActor(0)
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .unwrap();
     let actor_a = match execution.stack.last().copied() {
         Some(Value::Reference(addr)) => addr,
@@ -69,22 +57,17 @@ async fn send_and_receive_message_updates_reference_counts() {
     };
 
     OpCode::SpawnActor(0)
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .unwrap();
     let actor_b = match execution.stack.last().copied() {
         Some(Value::Reference(addr)) => addr,
         _ => panic!("Expected actor reference for message"),
     };
 
-    OpCode::Swap
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap();
+    OpCode::Swap.execute(&mut execution, &mut heap).unwrap();
 
     OpCode::SendMessage
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .unwrap();
 
     assert_eq!(actor_ref_count(&heap, actor_a), 1, "actor on stack");
@@ -94,7 +77,7 @@ async fn send_and_receive_message_updates_reference_counts() {
     let message = {
         let actor_entry = heap.get_mut(actor_a).expect("Expected actor VM for target");
         match actor_entry {
-            HeapObject::Actor(vm, _, _) => vm.mailbox.recv().await,
+            HeapObject::Actor(vm, _, _) => vm.mailbox_mut().recv().await,
             _ => panic!("Expected actor VM for target"),
         }
     }
@@ -112,21 +95,14 @@ async fn send_and_receive_message_updates_reference_counts() {
     tx.send(message).await.unwrap();
 
     OpCode::ReceiveMessage
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .unwrap();
 
     assert_eq!(actor_ref_count(&heap, actor_b), 1, "message now on stack");
 
     // Drop both stack references and collect.
-    OpCode::Pop
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap();
-    OpCode::Pop
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap();
+    OpCode::Pop.execute(&mut execution, &mut heap).unwrap();
+    OpCode::Pop.execute(&mut execution, &mut heap).unwrap();
     assert_eq!(actor_ref_count(&heap, actor_b), 0);
 
     heap.collect_garbage();
@@ -162,11 +138,9 @@ async fn vm_pop_stack_drops_actor_reference() {
 async fn neg_type_mismatch_consumes_reference_operand() {
     let mut execution = ExecutionContext::new(vec![OpCode::Return]);
     let mut heap = Heap::new();
-    let (_tx, mut mailbox) = channel(1);
 
     OpCode::SpawnActor(0)
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .unwrap();
 
     let address = match execution.stack.last().copied() {
@@ -174,10 +148,7 @@ async fn neg_type_mismatch_consumes_reference_operand() {
         other => panic!("Expected actor reference on stack, got {other:?}"),
     };
 
-    let err = OpCode::Neg
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap_err();
+    let err = OpCode::Neg.execute(&mut execution, &mut heap).unwrap_err();
     assert!(matches!(err, raft::vm::error::VmError::TypeMismatch("Neg")));
     assert!(execution.stack.is_empty(), "operand should be consumed");
     assert_eq!(actor_ref_count(&heap, address), 0);
@@ -190,11 +161,9 @@ async fn neg_type_mismatch_consumes_reference_operand() {
 async fn add_and_mod_type_mismatch_do_not_leak_references() {
     let mut execution = ExecutionContext::new(vec![OpCode::Return]);
     let mut heap = Heap::new();
-    let (_tx, mut mailbox) = channel(1);
 
     OpCode::SpawnActor(0)
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .unwrap();
     let add_ref = match execution.stack.last().copied() {
         Some(Value::Reference(addr)) => addr,
@@ -202,10 +171,7 @@ async fn add_and_mod_type_mismatch_do_not_leak_references() {
     };
     execution.stack.push(Value::Integer(1));
 
-    let add_err = OpCode::Add
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap_err();
+    let add_err = OpCode::Add.execute(&mut execution, &mut heap).unwrap_err();
     assert!(matches!(
         add_err,
         raft::vm::error::VmError::TypeMismatch("Add")
@@ -214,8 +180,7 @@ async fn add_and_mod_type_mismatch_do_not_leak_references() {
     assert_eq!(actor_ref_count(&heap, add_ref), 0);
 
     OpCode::SpawnActor(0)
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .unwrap();
     let mod_ref = match execution.stack.last().copied() {
         Some(Value::Reference(addr)) => addr,
@@ -223,10 +188,7 @@ async fn add_and_mod_type_mismatch_do_not_leak_references() {
     };
     execution.stack.push(Value::Integer(2));
 
-    let mod_err = OpCode::Mod
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
-        .unwrap_err();
+    let mod_err = OpCode::Mod.execute(&mut execution, &mut heap).unwrap_err();
     assert!(matches!(
         mod_err,
         raft::vm::error::VmError::TypeMismatch("Mod")

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -1,7 +1,6 @@
 use raft::vm::execution::ExecutionContext;
 use raft::vm::heap::{Heap, HeapObject};
 use raft::vm::{error::VmError, opcodes::OpCode, value::Value, vm::VM};
-use tokio::sync::mpsc::channel;
 
 #[tokio::test]
 async fn division_by_zero_returns_error() {
@@ -96,12 +95,10 @@ async fn spawn_supervisor_out_of_bounds_returns_error() {
 async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
     let mut execution = ExecutionContext::new(vec![OpCode::Return]);
     let mut heap = Heap::new();
-    let (_tx, mut mailbox) = channel(1);
 
     // Stack layout expected by SendMessage is [message, actor_ref].
     OpCode::SpawnActor(0)
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .expect("spawn actor should succeed");
     let actor_addr = match execution.stack.last().copied() {
         Some(Value::Reference(addr)) => addr,
@@ -110,12 +107,10 @@ async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
 
     let message_addr = heap.allocate(HeapObject::Array(vec![], 0));
     OpCode::PushConst(Value::Reference(message_addr))
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .expect("push message reference should succeed");
     OpCode::Swap
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .expect("swap should succeed");
 
     // Close actor mailbox to force ChannelSend error.
@@ -123,13 +118,12 @@ async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
         .get_mut(actor_addr)
         .expect("spawned actor should be in heap");
     match actor_entry {
-        HeapObject::Actor(actor_vm, _, _) => actor_vm.mailbox.close(),
+        HeapObject::Actor(actor_vm, _, _) => actor_vm.mailbox_mut().close(),
         other => panic!("expected actor in heap, got {other:?}"),
     }
 
     let err = OpCode::SendMessage
-        .execute(&mut execution, &mut heap, &mut mailbox)
-        .await
+        .execute(&mut execution, &mut heap)
         .expect_err("send should fail when mailbox is closed");
 
     match err {
@@ -161,9 +155,15 @@ async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
         }
         other => panic!("expected array at message_addr, got {other:?}"),
     }
+}
+
+#[tokio::test]
 async fn top_level_return_gracefully_halts_vm() {
     let code = vec![OpCode::Return];
     let (mut vm, _tx) = VM::new(code, None);
     let result = vm.run().await;
-    assert!(result.is_ok(), "expected top-level return to halt gracefully");
+    assert!(
+        result.is_ok(),
+        "expected top-level return to halt gracefully"
+    );
 }


### PR DESCRIPTION
### Motivation
- Remove per-instruction async overhead by making the VM dispatch loop synchronous so common instructions avoid Rust async state-machine costs.  
- Reduce opcode memory footprint and instruction-cache pressure by moving from fat `OpCode` variants (e.g. `PushConst(Value)`) to a dense `Vec<u8>` bytecode with a small constant pool.

### Description
- Introduced a compact `Bytecode` type with dense opcode bytes, a constant pool and per-instruction offsets, and an encoder/decoder between `OpCode` and the dense format (`src/vm/opcodes.rs`).
- Reworked instruction execution to be synchronous: `OpCode::execute` now returns `ExecutionState` and `ExecutionContext::step` returns `ExecutionState` (including `Yield(BlockingOperation)` and `Halted`) instead of being async; `ReceiveMessage` and `SendMessage` now `try_recv`/`try_send` and yield only when blocked (`src/vm/execution.rs`, `src/vm/opcodes.rs`).
- Replaced the old per-instruction await-based `VM::run` with a tight dispatch loop that calls `step` repeatedly and only awaits the runtime when a `BlockingOperation` is produced via `await_blocking_operation` (`src/vm/vm.rs`).
- Moved mailbox ownership into `ExecutionContext` and added `VM::mailbox_mut()` for tests/runtime to access it; updated actor runtime helpers to use the new mailbox accessors (`src/vm/execution.rs`, `src/vm/vm.rs`, `src/runtime.rs`).
- Updated/modernized tests and the compiler path to use the new `Bytecode`/sync APIs and added `tests/bytecode.rs` which verifies single-byte encodings for simple ops and constant-pool usage for `PushConst`.
- Addressed lints and adjusted a few helpers (added `Default` for `Heap`, allowed intentional `Value` arithmetic method names, fixed CLI derive attribute formatting and a small test float constant) so the repo is clippy-clean.

### Testing
- Ran `cargo fmt` to format changes successfully.  
- Ran `cargo test` (unit and integration tests across `src` and `tests/`), all test suites passed including the new `tests/bytecode.rs`.  
- Ran `cargo clippy --all-targets -- -D warnings` and fixed warnings to achieve a clean clippy run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd3dc31388328b9a0c8fd1d18174a)