### PR TITLE
Add lexer/parser frontend and source debug mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,12 @@ Pop
 true 3.14
 ```
 
-The current compiler tokenizes whitespace separated integers, floats
-(tokens containing a decimal point), booleans (`true`/`false`), basic
-arithmetic like `+`, and stack/variable keywords such as `StoreVar`,
-`LoadVar`, `Pop`, `Dup`, and `Swap`. Running the above file will leave
-`3`, `true`, and `3.14` on the VM's stack.
+The compiler now uses a lexer/parser pipeline that supports integers, floats,
+booleans (`true`/`false`), string literals with spaces (for example,
+`"hello raft vm"`), `#` and `//` comments, textual labels such as `.loop`,
+basic arithmetic like `+`, and stack/variable keywords such as `StoreVar`,
+`LoadVar`, `Pop`, `Dup`, and `Swap`. Running the above file will leave `3`,
+`true`, and `3.14` on the VM's stack.
 
 Native standard-library functions are injected when a VM starts. For example,
 `io.print` loads the standard `io` module's `print` export, and `CallNative 1`

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,7 +1,6 @@
-// src/compiler/compiler.rs
-
 use crate::vm::opcodes::OpCode;
 use crate::vm::value::Value;
+use std::collections::HashMap;
 use thiserror::Error;
 
 #[derive(Debug, Error, Clone)]
@@ -10,238 +9,633 @@ pub enum CompilerError {
     InvalidToken(String),
     #[error("Invalid address: {0}")]
     InvalidAddress(String),
+    #[error("Parse error at {line}:{column}: {message}")]
+    ParseErrorAt {
+        message: String,
+        line: usize,
+        column: usize,
+    },
     #[error("Parse error: {0}")]
     ParseError(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceLocation {
+    pub line: usize,
+    pub column: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceSpan {
+    pub start: SourceLocation,
+    pub end: SourceLocation,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DebugInfo {
+    instruction_spans: Vec<Option<SourceSpan>>,
+}
+
+impl DebugInfo {
+    pub fn new(instruction_spans: Vec<Option<SourceSpan>>) -> Self {
+        Self { instruction_spans }
+    }
+
+    pub fn span_for_instruction(&self, instruction: usize) -> Option<SourceSpan> {
+        self.instruction_spans.get(instruction).copied().flatten()
+    }
+
+    pub fn location_for_instruction(&self, instruction: usize) -> Option<SourceLocation> {
+        self.span_for_instruction(instruction)
+            .map(|span| span.start)
+    }
+
+    pub fn instruction_spans(&self) -> &[Option<SourceSpan>] {
+        &self.instruction_spans
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompiledProgram {
+    pub bytecode: Vec<OpCode>,
+    pub debug_info: DebugInfo,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TokenKind {
+    Identifier(String),
+    Label(String),
+    Integer(i32),
+    Float(f64),
+    Boolean(bool),
+    String(String),
+    Symbol(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddressOperand {
+    Address(usize),
+    Label(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Instruction {
+    PushConst(Value),
+    PushString(String),
+    StoreVar(usize),
+    LoadVar(usize),
+    LoadGlobal(String),
+    LoadIoPrint,
+    GetExport(String),
+    MakeArray(usize),
+    ArrayGet,
+    ArraySet,
+    MakeString(String),
+    StringConcat,
+    MakeModule(Vec<String>),
+    ModuleGet(String),
+    ModuleSet(String),
+    CallNative(usize),
+    Pop,
+    Dup,
+    Swap,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Neg,
+    Exp,
+    Jump(AddressOperand),
+    JumpIfFalse(AddressOperand),
+    Call(AddressOperand),
+    Return,
+    SpawnActor(AddressOperand),
+    SendMessage,
+    ReceiveMessage,
+    SpawnSupervisor(AddressOperand),
+    SetStrategy(usize),
+    RestartChild(usize),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AstNode {
+    Instruction {
+        instruction: Instruction,
+        span: SourceSpan,
+    },
+    Label {
+        name: String,
+        span: SourceSpan,
+    },
+}
+
+pub struct Lexer<'a> {
+    chars: std::iter::Peekable<std::str::CharIndices<'a>>,
+    line: usize,
+    column: usize,
+}
+
+impl<'a> Lexer<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Self {
+            chars: source.char_indices().peekable(),
+            line: 1,
+            column: 1,
+        }
+    }
+
+    pub fn lex(mut self) -> Result<Vec<Token>, CompilerError> {
+        let mut tokens = Vec::new();
+        while let Some((_, ch)) = self.peek() {
+            match ch {
+                c if c.is_whitespace() => {
+                    self.bump();
+                }
+                '#' => self.skip_line_comment(),
+                '/' if self.peek_next_char() == Some('/') => self.skip_line_comment(),
+                '"' => tokens.push(self.lex_string()?),
+                '+' | '-' | '*' | '/' | '%' | '^' => tokens.push(self.lex_symbol()),
+                _ => tokens.push(self.lex_word()?),
+            };
+        }
+        Ok(tokens)
+    }
+
+    fn peek(&mut self) -> Option<(usize, char)> {
+        self.chars.peek().copied()
+    }
+
+    fn peek_next_char(&self) -> Option<char> {
+        let mut chars = self.chars.clone();
+        chars.next();
+        chars.next().map(|(_, ch)| ch)
+    }
+
+    fn bump(&mut self) -> Option<(usize, char)> {
+        let next = self.chars.next()?;
+        if next.1 == '\n' {
+            self.line += 1;
+            self.column = 1;
+        } else {
+            self.column += 1;
+        }
+        Some(next)
+    }
+
+    fn location(&self) -> SourceLocation {
+        SourceLocation {
+            line: self.line,
+            column: self.column,
+        }
+    }
+
+    fn skip_line_comment(&mut self) {
+        while let Some((_, ch)) = self.peek() {
+            self.bump();
+            if ch == '\n' {
+                break;
+            }
+        }
+    }
+
+    fn lex_symbol(&mut self) -> Token {
+        let start = self.location();
+        let (_, ch) = self.bump().expect("symbol to exist");
+        Token {
+            kind: TokenKind::Symbol(ch.to_string()),
+            span: SourceSpan {
+                start,
+                end: self.location(),
+            },
+        }
+    }
+
+    fn lex_string(&mut self) -> Result<Token, CompilerError> {
+        let start = self.location();
+        self.bump();
+        let mut value = String::new();
+        while let Some((_, ch)) = self.bump() {
+            match ch {
+                '"' => {
+                    return Ok(Token {
+                        kind: TokenKind::String(value),
+                        span: SourceSpan {
+                            start,
+                            end: self.location(),
+                        },
+                    })
+                }
+                '\\' => {
+                    let Some((_, escaped)) = self.bump() else {
+                        return Err(self.error_at(start, "unterminated string escape"));
+                    };
+                    match escaped {
+                        'n' => value.push('\n'),
+                        'r' => value.push('\r'),
+                        't' => value.push('\t'),
+                        '"' => value.push('"'),
+                        '\\' => value.push('\\'),
+                        other => value.push(other),
+                    }
+                }
+                other => value.push(other),
+            }
+        }
+        Err(self.error_at(start, "unterminated string literal"))
+    }
+
+    fn lex_word(&mut self) -> Result<Token, CompilerError> {
+        let start = self.location();
+        let mut text = String::new();
+        while let Some((_, ch)) = self.peek() {
+            if ch.is_whitespace()
+                || ch == '"'
+                || ch == '#'
+                || (ch == '/' && self.peek_next_char() == Some('/'))
+            {
+                break;
+            }
+            text.push(ch);
+            self.bump();
+        }
+
+        if text.is_empty() {
+            return Err(self.error_at(start, "unexpected character"));
+        }
+
+        let kind = if text.starts_with('.') {
+            TokenKind::Label(text.trim_start_matches('.').to_string())
+        } else if text == "true" || text == "false" {
+            TokenKind::Boolean(text == "true")
+        } else if let Ok(value) = text.parse::<i32>() {
+            TokenKind::Integer(value)
+        } else if text.contains('.') {
+            match text.parse::<f64>() {
+                Ok(value) => TokenKind::Float(value),
+                Err(_) if text.chars().any(|ch| ch.is_ascii_digit()) => {
+                    return Err(CompilerError::ParseError(format!("Invalid float: {text}")))
+                }
+                Err(_) => TokenKind::Identifier(text),
+            }
+        } else {
+            TokenKind::Identifier(text)
+        };
+
+        Ok(Token {
+            kind,
+            span: SourceSpan {
+                start,
+                end: self.location(),
+            },
+        })
+    }
+
+    fn error_at(&self, location: SourceLocation, message: impl Into<String>) -> CompilerError {
+        CompilerError::ParseErrorAt {
+            message: message.into(),
+            line: location.line,
+            column: location.column,
+        }
+    }
+}
+
+pub struct Parser {
+    tokens: Vec<Token>,
+    current: usize,
+}
+
+impl Parser {
+    pub fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, current: 0 }
+    }
+
+    pub fn parse(mut self) -> Result<Vec<AstNode>, CompilerError> {
+        let mut nodes = Vec::new();
+        while !self.is_at_end() {
+            nodes.push(self.parse_node()?);
+        }
+        Ok(nodes)
+    }
+
+    fn parse_node(&mut self) -> Result<AstNode, CompilerError> {
+        let token = self.advance().clone();
+        match token.kind {
+            TokenKind::Integer(value) => {
+                Ok(self.instruction(Instruction::PushConst(Value::Integer(value)), token.span))
+            }
+            TokenKind::Float(value) => {
+                Ok(self.instruction(Instruction::PushConst(Value::Float(value)), token.span))
+            }
+            TokenKind::Boolean(value) => {
+                Ok(self.instruction(Instruction::PushConst(Value::Boolean(value)), token.span))
+            }
+            TokenKind::String(value) => {
+                Ok(self.instruction(Instruction::PushString(value), token.span))
+            }
+            TokenKind::Symbol(symbol) => self.parse_symbol(&symbol, token.span),
+            TokenKind::Label(name) => Ok(AstNode::Label {
+                name,
+                span: token.span,
+            }),
+            TokenKind::Identifier(identifier) => self.parse_identifier(&identifier, token.span),
+        }
+    }
+
+    fn parse_symbol(&self, symbol: &str, span: SourceSpan) -> Result<AstNode, CompilerError> {
+        let instruction = match symbol {
+            "+" => Instruction::Add,
+            "-" => Instruction::Sub,
+            "*" => Instruction::Mul,
+            "/" => Instruction::Div,
+            "%" => Instruction::Mod,
+            "^" => Instruction::Exp,
+            _ => return Err(CompilerError::InvalidToken(symbol.to_string())),
+        };
+        Ok(self.instruction(instruction, span))
+    }
+
+    fn parse_identifier(
+        &mut self,
+        identifier: &str,
+        span: SourceSpan,
+    ) -> Result<AstNode, CompilerError> {
+        let instruction = match identifier {
+            "io.print" => {
+                return Ok(self.instruction(Instruction::LoadIoPrint, span));
+            }
+            "StoreVar" => Instruction::StoreVar(self.expect_usize("StoreVar")?),
+            "LoadVar" => Instruction::LoadVar(self.expect_usize("LoadVar")?),
+            "LoadGlobal" => Instruction::LoadGlobal(self.expect_name("LoadGlobal")?),
+            "GetExport" => Instruction::GetExport(self.expect_name("GetExport")?),
+            "MakeArray" => Instruction::MakeArray(self.expect_usize("MakeArray")?),
+            "ArrayGet" => Instruction::ArrayGet,
+            "ArraySet" => Instruction::ArraySet,
+            "MakeString" => Instruction::MakeString(self.expect_string_or_name("MakeString")?),
+            "PushString" => Instruction::PushString(self.expect_string_or_name("PushString")?),
+            "StringConcat" => Instruction::StringConcat,
+            "MakeModule" => {
+                let count = self.expect_usize("MakeModule")?;
+                let mut exports = Vec::with_capacity(count);
+                for _ in 0..count {
+                    exports.push(self.expect_name("MakeModule")?);
+                }
+                Instruction::MakeModule(exports)
+            }
+            "ModuleGet" => Instruction::ModuleGet(self.expect_name("ModuleGet")?),
+            "ModuleSet" => Instruction::ModuleSet(self.expect_name("ModuleSet")?),
+            "CallNative" => Instruction::CallNative(self.expect_usize("CallNative")?),
+            "Pop" => Instruction::Pop,
+            "Dup" => Instruction::Dup,
+            "Swap" => Instruction::Swap,
+            "Add" => Instruction::Add,
+            "Sub" => Instruction::Sub,
+            "Mul" => Instruction::Mul,
+            "Div" => Instruction::Div,
+            "Mod" => Instruction::Mod,
+            "Neg" => Instruction::Neg,
+            "Exp" => Instruction::Exp,
+            "Jump" => Instruction::Jump(self.expect_address("Jump")?),
+            "JumpIfFalse" => Instruction::JumpIfFalse(self.expect_address("JumpIfFalse")?),
+            "Call" => Instruction::Call(self.expect_address("Call")?),
+            "Return" => Instruction::Return,
+            "SpawnActor" => Instruction::SpawnActor(self.expect_address("SpawnActor")?),
+            "SendMessage" => Instruction::SendMessage,
+            "ReceiveMessage" => Instruction::ReceiveMessage,
+            "SpawnSupervisor" => {
+                Instruction::SpawnSupervisor(self.expect_address("SpawnSupervisor")?)
+            }
+            "SetStrategy" => Instruction::SetStrategy(self.expect_usize("SetStrategy")?),
+            "RestartChild" => Instruction::RestartChild(self.expect_usize("RestartChild")?),
+            _ => return Err(CompilerError::InvalidToken(identifier.to_string())),
+        };
+        Ok(self.instruction(instruction, span))
+    }
+
+    fn instruction(&self, instruction: Instruction, span: SourceSpan) -> AstNode {
+        AstNode::Instruction { instruction, span }
+    }
+
+    fn expect_usize(&mut self, operation: &'static str) -> Result<usize, CompilerError> {
+        let token = self.expect_operand(operation)?;
+        match &token.kind {
+            TokenKind::Integer(value) if *value >= 0 => Ok(*value as usize),
+            TokenKind::Identifier(text) => text
+                .parse::<usize>()
+                .map_err(|_| CompilerError::InvalidAddress(text.clone())),
+            _ => Err(CompilerError::InvalidAddress(token_text(token))),
+        }
+    }
+
+    fn expect_address(&mut self, operation: &'static str) -> Result<AddressOperand, CompilerError> {
+        let token = self.expect_operand(operation)?;
+        match &token.kind {
+            TokenKind::Integer(value) if *value >= 0 => {
+                Ok(AddressOperand::Address(*value as usize))
+            }
+            TokenKind::Identifier(text) => text
+                .parse::<usize>()
+                .map(AddressOperand::Address)
+                .map_err(|_| CompilerError::InvalidAddress(text.clone())),
+            TokenKind::Label(name) => Ok(AddressOperand::Label(name.clone())),
+            _ => Err(CompilerError::InvalidAddress(token_text(token))),
+        }
+    }
+
+    fn expect_name(&mut self, operation: &'static str) -> Result<String, CompilerError> {
+        let token = self.expect_operand(operation)?;
+        match &token.kind {
+            TokenKind::Identifier(text) | TokenKind::Label(text) => Ok(text.clone()),
+            TokenKind::String(text) => Ok(text.clone()),
+            _ => Err(CompilerError::ParseError(format!(
+                "expected name after {operation}"
+            ))),
+        }
+    }
+
+    fn expect_string_or_name(&mut self, operation: &'static str) -> Result<String, CompilerError> {
+        let token = self.expect_operand(operation)?;
+        match &token.kind {
+            TokenKind::String(text) | TokenKind::Identifier(text) | TokenKind::Label(text) => {
+                Ok(text.clone())
+            }
+            _ => Err(CompilerError::ParseError(format!(
+                "expected string token after {operation}"
+            ))),
+        }
+    }
+
+    fn expect_operand(&mut self, operation: &'static str) -> Result<&Token, CompilerError> {
+        if self.is_at_end() {
+            return Err(CompilerError::InvalidAddress(format!(
+                "expected operand after {operation}"
+            )));
+        }
+        Ok(self.advance())
+    }
+
+    fn is_at_end(&self) -> bool {
+        self.current >= self.tokens.len()
+    }
+
+    fn advance(&mut self) -> &Token {
+        let token = &self.tokens[self.current];
+        self.current += 1;
+        token
+    }
 }
 
 pub struct Compiler;
 
 impl Compiler {
     pub fn compile(source: &str) -> Result<Vec<OpCode>, CompilerError> {
-        let mut bytecode = Vec::new();
+        Ok(Self::compile_with_debug(source)?.bytecode)
+    }
 
-        let mut tokens = source.split_whitespace();
-        while let Some(token) = tokens.next() {
-            if token == "true" || token == "false" {
-                bytecode.push(OpCode::PushConst(Value::Boolean(token == "true")));
-            } else if token == "io.print" {
-                bytecode.push(OpCode::LoadGlobal("io".to_string()));
-                bytecode.push(OpCode::GetExport("print".to_string()));
-            } else if token.contains('.') {
-                let num = token
-                    .parse::<f64>()
-                    .map_err(|_| CompilerError::ParseError(format!("Invalid float: {}", token)))?;
-                bytecode.push(OpCode::PushConst(Value::Float(num)));
-            } else if let Ok(num) = token.parse::<i32>() {
-                bytecode.push(OpCode::PushConst(Value::Integer(num)));
-            } else {
-                match token {
-                    "StoreVar" => {
-                        let index_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected variable index after StoreVar".into(),
-                            )
-                        })?;
-                        let index = index_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(index_token.to_string()))?;
-                        bytecode.push(OpCode::StoreVar(index));
-                    }
-                    "LoadVar" => {
-                        let index_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected variable index after LoadVar".into(),
-                            )
-                        })?;
-                        let index = index_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(index_token.to_string()))?;
-                        bytecode.push(OpCode::LoadVar(index));
-                    }
-                    "MakeArray" => {
-                        let length_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress("expected length after MakeArray".into())
-                        })?;
-                        let length = length_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(length_token.to_string()))?;
-                        bytecode.push(OpCode::MakeArray(length));
-                    }
-                    "ArrayGet" => bytecode.push(OpCode::ArrayGet),
-                    "ArraySet" => bytecode.push(OpCode::ArraySet),
-                    "MakeString" => {
-                        let value = tokens.next().ok_or_else(|| {
-                            CompilerError::ParseError(
-                                "expected string token after MakeString".into(),
-                            )
-                        })?;
-                        bytecode.push(OpCode::MakeString(value.to_string()));
-                    }
-                    "StringConcat" => bytecode.push(OpCode::StringConcat),
-                    "MakeModule" => {
-                        let export_count_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected export count after MakeModule".into(),
-                            )
-                        })?;
-                        let export_count = export_count_token.parse::<usize>().map_err(|_| {
-                            CompilerError::InvalidAddress(export_count_token.to_string())
-                        })?;
-                        let mut exports = Vec::with_capacity(export_count);
-                        for _ in 0..export_count {
-                            exports.push(
-                                tokens
-                                    .next()
-                                    .ok_or_else(|| {
-                                        CompilerError::ParseError(
-                                            "expected export name after MakeModule".into(),
-                                        )
-                                    })?
-                                    .to_string(),
-                            );
-                        }
-                        bytecode.push(OpCode::MakeModule(exports));
-                    }
-                    "ModuleGet" => {
-                        let name = tokens.next().ok_or_else(|| {
-                            CompilerError::ParseError("expected export name after ModuleGet".into())
-                        })?;
-                        bytecode.push(OpCode::ModuleGet(name.to_string()));
-                    }
-                    "ModuleSet" => {
-                        let name = tokens.next().ok_or_else(|| {
-                            CompilerError::ParseError("expected export name after ModuleSet".into())
-                        })?;
-                        bytecode.push(OpCode::ModuleSet(name.to_string()));
-                    }
-                    "CallNative" => {
-                        let arity_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress("expected arity after CallNative".into())
-                        })?;
-                        let arity = arity_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(arity_token.to_string()))?;
-                        bytecode.push(OpCode::CallNative(arity));
-                    "LoadGlobal" => {
-                        let name = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected global name after LoadGlobal".into(),
-                            )
-                        })?;
-                        bytecode.push(OpCode::LoadGlobal(name.to_string()));
-                    }
-                    "GetExport" => {
-                        let name = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected export name after GetExport".into(),
-                            )
-                        })?;
-                        bytecode.push(OpCode::GetExport(name.to_string()));
-                    }
-                    "Pop" => bytecode.push(OpCode::Pop),
-                    "Dup" => bytecode.push(OpCode::Dup),
-                    "Swap" => bytecode.push(OpCode::Swap),
-                    "+" | "Add" => bytecode.push(OpCode::Add),
-                    "-" | "Sub" => bytecode.push(OpCode::Sub),
-                    "*" | "Mul" => bytecode.push(OpCode::Mul),
-                    "/" | "Div" => bytecode.push(OpCode::Div),
-                    "%" | "Mod" => bytecode.push(OpCode::Mod),
-                    "Neg" => bytecode.push(OpCode::Neg),
-                    "Exp" | "^" => bytecode.push(OpCode::Exp),
-                    "Jump" => {
-                        let addr_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress("expected address after Jump".into())
-                        })?;
-                        let addr = addr_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(addr_token.to_string()))?;
-                        bytecode.push(OpCode::Jump(addr));
-                    }
-                    "JumpIfFalse" => {
-                        let addr_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected address after JumpIfFalse".into(),
-                            )
-                        })?;
-                        let addr = addr_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(addr_token.to_string()))?;
-                        bytecode.push(OpCode::JumpIfFalse(addr));
-                    }
-                    "Call" => {
-                        let addr_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress("expected address after Call".into())
-                        })?;
-                        let addr = addr_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(addr_token.to_string()))?;
-                        bytecode.push(OpCode::Call(addr));
-                    }
-                    "CallNative" => {
-                        let arity_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress("expected arity after CallNative".into())
-                        })?;
-                        let arity = arity_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(arity_token.to_string()))?;
-                        bytecode.push(OpCode::CallNative(arity));
-                    }
-                    "SpawnActor" => {
-                        let addr_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected address after SpawnActor".into(),
-                            )
-                        })?;
-                        let addr = addr_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(addr_token.to_string()))?;
-                        bytecode.push(OpCode::SpawnActor(addr));
-                    }
-                    "SendMessage" => {
-                        bytecode.push(OpCode::SendMessage);
-                    }
-                    "ReceiveMessage" => {
-                        bytecode.push(OpCode::ReceiveMessage);
-                    }
-                    "SpawnSupervisor" => {
-                        let addr_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected address after SpawnSupervisor".into(),
-                            )
-                        })?;
-                        let addr = addr_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(addr_token.to_string()))?;
-                        bytecode.push(OpCode::SpawnSupervisor(addr));
-                    }
-                    "SetStrategy" => {
-                        let strategy_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected strategy after SetStrategy".into(),
-                            )
-                        })?;
-                        let strategy = strategy_token.parse::<usize>().map_err(|_| {
-                            CompilerError::InvalidAddress(strategy_token.to_string())
-                        })?;
-                        bytecode.push(OpCode::SetStrategy(strategy));
-                    }
-                    "RestartChild" => {
-                        let child_token = tokens.next().ok_or_else(|| {
-                            CompilerError::InvalidAddress(
-                                "expected child index after RestartChild".into(),
-                            )
-                        })?;
-                        let child = child_token
-                            .parse::<usize>()
-                            .map_err(|_| CompilerError::InvalidAddress(child_token.to_string()))?;
-                        bytecode.push(OpCode::RestartChild(child));
-                    }
-                    "Return" => bytecode.push(OpCode::Return),
-                    _ => return Err(CompilerError::InvalidToken(token.to_string())),
-                }
+    pub fn compile_with_debug(source: &str) -> Result<CompiledProgram, CompilerError> {
+        let tokens = Lexer::new(source).lex()?;
+        let ast = Parser::new(tokens).parse()?;
+        emit(ast)
+    }
+}
+
+fn token_text(token: &Token) -> String {
+    match &token.kind {
+        TokenKind::Identifier(text)
+        | TokenKind::Label(text)
+        | TokenKind::String(text)
+        | TokenKind::Symbol(text) => text.clone(),
+        TokenKind::Integer(value) => value.to_string(),
+        TokenKind::Float(value) => value.to_string(),
+        TokenKind::Boolean(value) => value.to_string(),
+    }
+}
+
+fn emit(ast: Vec<AstNode>) -> Result<CompiledProgram, CompilerError> {
+    let mut labels = HashMap::new();
+    let mut offset = 0usize;
+
+    for node in &ast {
+        match node {
+            AstNode::Label { name, .. } => {
+                labels.insert(name.clone(), offset);
+            }
+            AstNode::Instruction { instruction, .. } => {
+                offset += emitted_len(instruction);
             }
         }
-
-        Ok(bytecode)
     }
+
+    let mut bytecode = Vec::new();
+    let mut spans = Vec::new();
+    for node in ast {
+        if let AstNode::Instruction { instruction, span } = node {
+            emit_instruction(instruction, span, &labels, &mut bytecode, &mut spans)?;
+        }
+    }
+
+    Ok(CompiledProgram {
+        bytecode,
+        debug_info: DebugInfo::new(spans),
+    })
+}
+
+fn emitted_len(instruction: &Instruction) -> usize {
+    match instruction {
+        Instruction::LoadIoPrint => 2,
+        _ => 1,
+    }
+}
+
+fn resolve_address(
+    operand: AddressOperand,
+    labels: &HashMap<String, usize>,
+) -> Result<usize, CompilerError> {
+    match operand {
+        AddressOperand::Address(address) => Ok(address),
+        AddressOperand::Label(label) => {
+            labels
+                .get(&label)
+                .copied()
+                .ok_or(CompilerError::InvalidAddress(format!(
+                    "unknown label .{label}"
+                )))
+        }
+    }
+}
+
+fn push(
+    bytecode: &mut Vec<OpCode>,
+    spans: &mut Vec<Option<SourceSpan>>,
+    opcode: OpCode,
+    span: SourceSpan,
+) {
+    bytecode.push(opcode);
+    spans.push(Some(span));
+}
+
+fn emit_instruction(
+    instruction: Instruction,
+    span: SourceSpan,
+    labels: &HashMap<String, usize>,
+    bytecode: &mut Vec<OpCode>,
+    spans: &mut Vec<Option<SourceSpan>>,
+) -> Result<(), CompilerError> {
+    let opcode = match instruction {
+        Instruction::PushConst(value) => OpCode::PushConst(value),
+        Instruction::PushString(value) => OpCode::PushString(value),
+        Instruction::StoreVar(index) => OpCode::StoreVar(index),
+        Instruction::LoadVar(index) => OpCode::LoadVar(index),
+        Instruction::LoadGlobal(name) => OpCode::LoadGlobal(name),
+        Instruction::LoadIoPrint => {
+            push(bytecode, spans, OpCode::LoadGlobal("io".to_string()), span);
+            push(
+                bytecode,
+                spans,
+                OpCode::GetExport("print".to_string()),
+                span,
+            );
+            return Ok(());
+        }
+        Instruction::GetExport(name) => OpCode::GetExport(name),
+        Instruction::MakeArray(length) => OpCode::MakeArray(length),
+        Instruction::ArrayGet => OpCode::ArrayGet,
+        Instruction::ArraySet => OpCode::ArraySet,
+        Instruction::MakeString(value) => OpCode::MakeString(value),
+        Instruction::StringConcat => OpCode::StringConcat,
+        Instruction::MakeModule(exports) => OpCode::MakeModule(exports),
+        Instruction::ModuleGet(name) => OpCode::ModuleGet(name),
+        Instruction::ModuleSet(name) => OpCode::ModuleSet(name),
+        Instruction::CallNative(arity) => OpCode::CallNative(arity),
+        Instruction::Pop => OpCode::Pop,
+        Instruction::Dup => OpCode::Dup,
+        Instruction::Swap => OpCode::Swap,
+        Instruction::Add => OpCode::Add,
+        Instruction::Sub => OpCode::Sub,
+        Instruction::Mul => OpCode::Mul,
+        Instruction::Div => OpCode::Div,
+        Instruction::Mod => OpCode::Mod,
+        Instruction::Neg => OpCode::Neg,
+        Instruction::Exp => OpCode::Exp,
+        Instruction::Jump(address) => OpCode::Jump(resolve_address(address, labels)?),
+        Instruction::JumpIfFalse(address) => OpCode::JumpIfFalse(resolve_address(address, labels)?),
+        Instruction::Call(address) => OpCode::Call(resolve_address(address, labels)?),
+        Instruction::Return => OpCode::Return,
+        Instruction::SpawnActor(address) => OpCode::SpawnActor(resolve_address(address, labels)?),
+        Instruction::SendMessage => OpCode::SendMessage,
+        Instruction::ReceiveMessage => OpCode::ReceiveMessage,
+        Instruction::SpawnSupervisor(address) => {
+            OpCode::SpawnSupervisor(resolve_address(address, labels)?)
+        }
+        Instruction::SetStrategy(strategy) => OpCode::SetStrategy(strategy),
+        Instruction::RestartChild(child) => OpCode::RestartChild(child),
+    };
+    push(bytecode, spans, opcode, span);
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Runs a Raft program from source code
 pub async fn run(source: &str) -> Result<(), VmError> {
-    let bytecode = Compiler::compile(source)?;
+    let program = Compiler::compile_with_debug(source)?;
 
-    let (mut vm, _tx) = VM::new(bytecode, None);
+    let (mut vm, _tx) = VM::new_with_debug(program.bytecode, Some(program.debug_info), None);
     vm.run().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,9 +164,9 @@ async fn start_repl() {
 fn repl_input_is_incomplete(source: &str, error: &CompilerError) -> bool {
     match error {
         CompilerError::InvalidAddress(message) => message.starts_with("expected "),
-        CompilerError::InvalidToken(_) | CompilerError::ParseError(_) => {
-            delimiters_are_unclosed(source)
-        }
+        CompilerError::InvalidToken(_)
+        | CompilerError::ParseError(_)
+        | CompilerError::ParseErrorAt { .. } => delimiters_are_unclosed(source),
     }
 }
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -46,5 +46,6 @@ fn display_value(value: &Value) -> String {
         Value::Boolean(value) => value.to_string(),
         Value::Reference(address) => format!("<ref:{address}>"),
         Value::Null => "null".to_string(),
+        Value::ExitSignal(signal) => format!("<exit:{}:{:?}>", signal.from, signal.reason),
     }
 }

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -1,11 +1,16 @@
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
 
-use crate::compiler::CompilerError;
+use crate::compiler::{CompilerError, SourceLocation};
 use crate::vm::value::Value;
 
 #[derive(Error, Debug, Clone)]
 pub enum VmError {
+    #[error("{source} at {line}:{column}", line = location.line, column = location.column)]
+    RuntimeError {
+        location: SourceLocation,
+        source: Box<VmError>,
+    },
     #[error("{0}")]
     Message(String),
     #[error("Stack underflow")]

--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use crate::compiler::DebugInfo;
 use crate::vm::error::VmError;
 use crate::vm::heap::Heap;
 use crate::vm::opcodes::OpCode;
@@ -24,6 +25,7 @@ pub struct ExecutionContext {
     pub ip: usize,
     pub call_stack: Vec<usize>,
     pub bytecode: Vec<OpCode>,
+    pub debug_info: Option<DebugInfo>,
 }
 
 impl ExecutionContext {
@@ -35,6 +37,19 @@ impl ExecutionContext {
             ip: 0,
             call_stack: Vec::new(),
             bytecode,
+            debug_info: None,
+        }
+    }
+
+    pub fn new_with_debug(bytecode: Vec<OpCode>, debug_info: Option<DebugInfo>) -> Self {
+        Self {
+            stack: Vec::new(),
+            locals: HashMap::new(),
+            globals: HashMap::new(),
+            ip: 0,
+            call_stack: Vec::new(),
+            bytecode,
+            debug_info,
         }
     }
 
@@ -77,13 +92,33 @@ impl ExecutionContext {
             return Err(VmError::ExecutionOutOfBounds);
         }
 
-        let opcode = self.bytecode[self.ip];
+        let instruction_ip = self.ip;
+        let opcode = self.bytecode[self.ip].clone();
         // advance instruction pointer unless opcode modified it
         self.ip += 1;
         log::info!("Executing opcode: {:?}", opcode);
         opcode
             .execute_with_process(self, heap, mailbox, process)
             .await
+            .map_err(|error| self.with_debug_location(error, instruction_ip))
+    }
+
+    fn with_debug_location(&self, error: VmError, instruction_ip: usize) -> VmError {
+        if matches!(error, VmError::RuntimeError { .. }) {
+            return error;
+        }
+
+        match self
+            .debug_info
+            .as_ref()
+            .and_then(|debug_info| debug_info.location_for_instruction(instruction_ip))
+        {
+            Some(location) => VmError::RuntimeError {
+                location,
+                source: Box::new(error),
+            },
+            None => error,
+        }
     }
 
     pub fn ip(&self) -> usize {

--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -169,12 +169,6 @@ impl Heap {
     }
 }
 
-impl Default for Heap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl HeapObject {
     pub fn is_alive(&self) -> bool {
         self.ref_count() > 0

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -1,9 +1,8 @@
 // src/vm/opcodes.rs
 
 use crate::vm::error::VmError;
-use crate::vm::execution::ExecutionContext;
-use crate::vm::heap::{Heap, HeapObject, NativeFunction};
 use crate::vm::execution::{ExecutionContext, ProcessContext};
+use crate::vm::heap::{Heap, HeapObject, NativeFunction};
 use crate::vm::supervision::ChildSpec;
 use crate::vm::value::Value;
 use crate::vm::vm::VM;
@@ -311,6 +310,20 @@ fn module_set(
     push_value(execution, heap, Value::Reference(address))
 }
 
+fn native_function_at(
+    execution: &ExecutionContext,
+    heap: &Heap,
+    stack_index: usize,
+) -> Option<NativeFunction> {
+    match execution.stack.get(stack_index) {
+        Some(Value::Reference(address)) => match heap.get(*address) {
+            Some(HeapObject::NativeFunction(function, _)) => Some(function.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 fn call_native(
     execution: &mut ExecutionContext,
     heap: &mut Heap,
@@ -320,26 +333,33 @@ fn call_native(
         return Err(VmError::StackUnderflowFor("CallNative"));
     }
 
-    let mut args = Vec::with_capacity(arity);
-    for _ in 0..arity {
-        args.push(pop_value(execution, heap)?);
-    }
-    args.reverse();
-
-    let function_ref = pop_value(execution, heap)?;
-    let function = match function_ref {
-        Value::Reference(address) => match heap.get(address) {
-            Some(HeapObject::NativeFunction(function, _)) => function.clone(),
-            _ => return Err(VmError::InvalidReference),
-        },
-        _ => return Err(VmError::TypeMismatch("CallNative")),
-    };
+    let top_index = execution.stack.len() - 1;
+    let function_index = execution.stack.len() - arity - 1;
+    let function = native_function_at(execution, heap, top_index)
+        .or_else(|| native_function_at(execution, heap, function_index))
+        .ok_or(VmError::InvalidReference)?;
 
     if function.arity != arity {
         return Err(VmError::NativeArityMismatch {
             expected: function.arity,
             actual: arity,
         });
+    }
+
+    let callable_on_top = native_function_at(execution, heap, top_index).is_some();
+    let mut args = Vec::with_capacity(arity);
+    if callable_on_top {
+        pop_value(execution, heap)?;
+        for _ in 0..arity {
+            args.push(pop_value(execution, heap)?);
+        }
+        args.reverse();
+    } else {
+        for _ in 0..arity {
+            args.push(pop_value(execution, heap)?);
+        }
+        args.reverse();
+        pop_value(execution, heap)?;
     }
 
     let result = (function.function)(args)?;
@@ -374,12 +394,12 @@ pub enum OpCode {
     ArrayGet,
     ArraySet,
     MakeString(String),
+    PushString(String),
     StringConcat,
     MakeModule(Vec<String>),
     ModuleGet(String),
     ModuleSet(String),
     MakeNativeFunction(NativeFunction),
-    CallNative(usize),
 
     // Control Flow
     Jump(usize),
@@ -521,7 +541,7 @@ impl OpCode {
             }),
             OpCode::ArrayGet => array_get(execution, heap),
             OpCode::ArraySet => array_set(execution, heap),
-            OpCode::MakeString(value) => {
+            OpCode::MakeString(value) | OpCode::PushString(value) => {
                 let address = heap.allocate(HeapObject::String(value.clone(), 0));
                 push_value(execution, heap, Value::Reference(address))
             }
@@ -533,7 +553,6 @@ impl OpCode {
                 let address = heap.allocate(HeapObject::NativeFunction(function.clone(), 0));
                 push_value(execution, heap, Value::Reference(address))
             }
-            OpCode::CallNative(arity) => call_native(execution, heap, *arity),
             OpCode::Jump(target) => {
                 if *target > execution.bytecode.len() {
                     log::error!(
@@ -582,38 +601,7 @@ impl OpCode {
                 Ok(())
             }
 
-            OpCode::CallNative(arity) => {
-                let callable = pop_value(execution, heap)?;
-                let Value::Reference(address) = callable else {
-                    return Err(VmError::InvalidReference);
-                };
-
-                let native = match heap.get(address) {
-                    Some(HeapObject::NativeFunction(native, _)) => native,
-                    _ => return Err(VmError::InvalidReference),
-                };
-
-                if native.arity != *arity {
-                    return Err(VmError::Message(format!(
-                        "Native function `{}` expected {} argument(s), got {}",
-                        native.name, native.arity, arity
-                    )));
-                }
-
-                if execution.stack.len() < *arity {
-                    return Err(VmError::StackUnderflowFor("CallNative"));
-                }
-
-                let function = native.function;
-                let mut args = Vec::with_capacity(*arity);
-                for _ in 0..*arity {
-                    args.push(pop_value(execution, heap)?);
-                }
-                args.reverse();
-
-                let result = function(args)?;
-                push_value(execution, heap, result)
-            }
+            OpCode::CallNative(arity) => call_native(execution, heap, *arity),
             OpCode::Return => {
                 if let Some(return_addr) = execution.call_stack.pop() {
                     execution.ip = return_addr;
@@ -638,7 +626,7 @@ impl OpCode {
 
             OpCode::SpawnActor(addr) => {
                 let bytecode = execution.bytecode.clone();
-                let (mut vm, tx) = VM::new(bytecode, None);
+                let (mut vm, tx) = VM::new_with_debug(bytecode, execution.debug_info.clone(), None);
                 if *addr > execution.bytecode.len() {
                     log::error!(
                         "SpawnActor target {} out of bounds (bytecode length {})",
@@ -696,7 +684,7 @@ impl OpCode {
             }
             OpCode::SpawnSupervisor(addr) => {
                 let bytecode = execution.bytecode.clone();
-                let (mut vm, tx) = VM::new(bytecode, None);
+                let (mut vm, tx) = VM::new_with_debug(bytecode, execution.debug_info.clone(), None);
                 if *addr > execution.bytecode.len() {
                     log::error!(
                         "SpawnSupervisor target {} out of bounds (bytecode length {})",

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -1,5 +1,6 @@
 // src/vm/vm.rs
 
+use crate::compiler::DebugInfo;
 use crate::stdlib;
 use crate::vm::error::VmError;
 use crate::vm::execution::ExecutionContext;
@@ -32,9 +33,17 @@ pub struct VM {
 
 impl VM {
     pub fn new(bytecode: Vec<OpCode>, supervisor: Option<Sender<usize>>) -> (Self, Sender<Value>) {
+        Self::new_with_debug(bytecode, None, supervisor)
+    }
+
+    pub fn new_with_debug(
+        bytecode: Vec<OpCode>,
+        debug_info: Option<DebugInfo>,
+        supervisor: Option<Sender<usize>>,
+    ) -> (Self, Sender<Value>) {
         let (tx, rx) = mpsc::channel(100);
         log::info!("Initializing VM with {} opcodes", bytecode.len());
-        let mut execution = ExecutionContext::new(bytecode);
+        let mut execution = ExecutionContext::new_with_debug(bytecode, debug_info);
         let mut heap = Heap::new();
         stdlib::install(&mut heap, &mut execution);
 
@@ -205,7 +214,8 @@ impl VM {
 
     pub fn reset_for_restart(&mut self, start_ip: usize) {
         let bytecode = self.execution.bytecode.clone();
-        self.execution = ExecutionContext::new(bytecode);
+        let debug_info = self.execution.debug_info.clone();
+        self.execution = ExecutionContext::new_with_debug(bytecode, debug_info);
         self.execution.ip = start_ip;
     }
 

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -172,3 +172,47 @@ fn compile_native_io_print_tokens() {
     assert!(matches!(&bytecode[2], OpCode::GetExport(name) if name == "print"));
     assert!(matches!(bytecode[3], OpCode::CallNative(1)));
 }
+
+#[test]
+fn compile_string_literals_comments_and_labels() {
+    let source = r#"
+        # string literal preserves spaces
+        "hello raft vm"
+        true JumpIfFalse .done
+        // comments are ignored
+        Jump .done
+        .done
+        Return
+    "#;
+
+    let program = Compiler::compile_with_debug(source).unwrap();
+
+    assert!(matches!(&program.bytecode[0], OpCode::PushString(value) if value == "hello raft vm"));
+    assert!(matches!(
+        program.bytecode[1],
+        OpCode::PushConst(Value::Boolean(true))
+    ));
+    assert!(matches!(program.bytecode[2], OpCode::JumpIfFalse(4)));
+    assert!(matches!(program.bytecode[3], OpCode::Jump(4)));
+    assert!(matches!(program.bytecode[4], OpCode::Return));
+
+    let span = program.debug_info.span_for_instruction(0).unwrap();
+    assert_eq!(span.start.line, 3);
+    assert_eq!(span.start.column, 9);
+}
+
+#[tokio::test]
+async fn run_wraps_runtime_errors_with_source_location() {
+    let err = run("\n42\nJump 99\n")
+        .await
+        .expect_err("expected runtime error");
+
+    match err {
+        VmError::RuntimeError { location, source } => {
+            assert_eq!(location.line, 3);
+            assert_eq!(location.column, 1);
+            assert!(matches!(*source, VmError::ExecutionOutOfBounds));
+        }
+        other => panic!("expected source-mapped runtime error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace the fragile whitespace-only front-end with a real lexer/parser so the language can support string literals, comments, textual labels, and richer operands. 
- Allow authors to write control flow using textual labels (e.g. `.loop_start`) instead of hand-maintained numeric offsets. 
- Provide source-level debug mapping so runtime errors can be reported with precise source line/column locations. 

### Description
- Implement a full front end (`Lexer`, `Token`/`TokenKind`, `Parser`, `AstNode`, `Instruction`) and an emission pass producing `CompiledProgram { bytecode, debug_info }` with per-instruction `SourceSpan`/`SourceLocation`. 
- Add string literal lexing and a `PushString` opcode that allocates heap strings at runtime so literals with spaces (e.g. `"hello raft vm"`) are preserved. 
- Add textual label tokens and a label resolution pass (`AddressOperand::Label → instruction offsets`) used when emitting `Jump`/`Call`/`JumpIfFalse`/`SpawnActor`/`SpawnSupervisor` operands. 
- Thread `DebugInfo` through `ExecutionContext` and `VM` (`new_with_debug`), preserve it for spawned actors/supervisors, and wrap runtime errors as `VmError::RuntimeError { location, source }` when debug info maps the failing instruction. 

### Testing
- Ran the full test suite with `cargo test` and all tests passed (unit tests and integration tests). 
- Ran static checks with `cargo clippy --all-targets -- -D warnings` and the linter passed with no warnings treated as errors. 
- Added tests validating comments, string literals, textual labels and source-mapped runtime errors in `tests/compiler.rs`, and they passed under the automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fded2f0efc8328ac20b481de70799e)