### PR TITLE
Import OpCode directly in VM module

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -5,7 +5,7 @@ use crate::stdlib;
 use crate::vm::error::VmError;
 use crate::vm::execution::{BlockingOperation, ExecutionContext, ExecutionState};
 use crate::vm::heap::{Heap, HeapObject};
-use crate::vm::opcodes::Bytecode;
+use crate::vm::opcodes::{Bytecode, OpCode};
 use crate::vm::supervision::{
     ChildSpec, ExitReason, ExitSignal, SupervisorState, SupervisorStrategy,
 };


### PR DESCRIPTION
### Motivation
- Ensure the `VM::new` and `VM::new_with_debug` signatures that take `Vec<OpCode>` in `src/vm/vm.rs` resolve locally without relying on parent-module re-exports by making `OpCode` available in the VM module.

### Description
- Replace `use crate::vm::opcodes::Bytecode;` with `use crate::vm::opcodes::{Bytecode, OpCode};` in `src/vm/vm.rs` so `OpCode` is imported alongside `Bytecode` for the VM constructors.

### Testing
- Ran `rustfmt src/vm/vm.rs --edition 2021 --check`, which succeeded for the modified file.
- Ran `cargo check` and `cargo fmt --check`, which could not complete due to an existing unrelated parse error (unclosed delimiter) in `src/compiler.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1f74f6a08328877b34ad8f4dc0bc)