### PR TITLE
Remove default VM mailbox seeding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use std::fs;
 use std::process;
 
 use raft::compiler::{Compiler, CompilerError};
-use raft::vm::value::Value;
 use raft::vm::{VmError, VM};
 
 use std::io::Write;
@@ -66,17 +65,7 @@ async fn handle_run(filename: &str) {
                     process::exit(1);
                 }
             };
-            let (mut vm, tx) = VM::new(bytecode, None);
-
-            // Simulate sending messages to the VM
-            tokio::spawn(async move {
-                if let Err(e) = tx.send(Value::Integer(42)).await {
-                    eprintln!("Send error: {}", e);
-                }
-                if let Err(e) = tx.send(Value::Boolean(true)).await {
-                    eprintln!("Send error: {}", e);
-                }
-            });
+            let (mut vm, _tx) = VM::new(bytecode, None);
 
             if let Err(e) = vm.run().await {
                 eprintln!("Execution error: {}", e);


### PR DESCRIPTION
### Motivation
- The `raft run` command implicitly seeded every new VM with example mailbox messages via a background Tokio task, altering default runtime behavior; this change removes that implicit seeding so runs are deterministic and examples can opt-in explicitly.

### Description
- Remove the Tokio spawn in `handle_run` that sent `Value::Integer(42)` and `Value::Boolean(true)` into the VM mailbox in `src/main.rs`.
- Remove the now-unused `use raft::vm::value::Value;` import and keep the mailbox sender as an intentionally unused `_tx` returned from `VM::new`.

### Testing
- Ran `git diff --check`, which reported no issues.
- Ran `cargo test`, which failed due to an existing parse error in `src/compiler.rs` unrelated to this change.
- Ran `cargo fmt -- --check`, which also failed for the same unrelated parse error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1f7e9bd88328811177fc6004dfb7)