### PR TITLE
Remove duplicate ExitSignal display arm

### DIFF
--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -47,6 +47,5 @@ fn display_value(value: &Value) -> String {
         Value::Reference(address) => format!("<ref:{address}>"),
         Value::ExitSignal(signal) => format!("<exit:{}:{:?}>", signal.from, signal.reason),
         Value::Null => "null".to_string(),
-        Value::ExitSignal(signal) => format!("<exit:{}:{:?}>", signal.from, signal.reason),
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure `Value::ExitSignal` is displayed only once by removing a duplicated match arm in `display_value` while preserving the existing output format.

### Description
- Deleted the duplicated `Value::ExitSignal` arm in `display_value` in `src/stdlib.rs`, keeping the `"<exit:{from}:{reason:?}>"` formatting and leaving other `Value` variants unchanged.

### Testing
- Ran `git diff --check` which passed, and ran `cargo test` which failed due to an unrelated `src/compiler.rs` unclosed delimiter error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1f772b608328b1a667ba8466498a)