### PR TITLE
Reject spawn targets at bytecode length

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -898,7 +898,7 @@ impl OpCode {
             OpCode::SpawnActor(addr) => {
                 let bytecode = execution.bytecode.clone();
                 let (mut vm, tx) = VM::new_with_debug(bytecode, execution.debug_info.clone(), None);
-                if *addr > execution.bytecode.len() {
+                if *addr >= execution.bytecode.len() {
                     log::error!(
                         "SpawnActor target {} out of bounds (bytecode length {})",
                         addr,
@@ -956,7 +956,7 @@ impl OpCode {
             OpCode::SpawnSupervisor(addr) => {
                 let bytecode = execution.bytecode.clone();
                 let (mut vm, tx) = VM::new_with_debug(bytecode, execution.debug_info.clone(), None);
-                if *addr > execution.bytecode.len() {
+                if *addr >= execution.bytecode.len() {
                     log::error!(
                         "SpawnSupervisor target {} out of bounds (bytecode length {})",
                         addr,

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -92,6 +92,28 @@ async fn spawn_supervisor_out_of_bounds_returns_error() {
 }
 
 #[tokio::test]
+async fn spawn_actor_at_bytecode_len_returns_error() {
+    let code = vec![OpCode::SpawnActor(1)];
+    let (mut vm, _tx) = VM::new(code, None);
+    let err = vm
+        .run()
+        .await
+        .expect_err("expected execution out of bounds for spawn actor at bytecode length");
+    assert!(matches!(err, VmError::ExecutionOutOfBounds));
+}
+
+#[tokio::test]
+async fn spawn_supervisor_at_bytecode_len_returns_error() {
+    let code = vec![OpCode::SpawnSupervisor(1)];
+    let (mut vm, _tx) = VM::new(code, None);
+    let err = vm
+        .run()
+        .await
+        .expect_err("expected execution out of bounds for spawn supervisor at bytecode length");
+    assert!(matches!(err, VmError::ExecutionOutOfBounds));
+}
+
+#[tokio::test]
 async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
     let mut execution = ExecutionContext::new(vec![OpCode::Return]);
     let mut heap = Heap::new();


### PR DESCRIPTION
### Motivation
- Prevent spawning child VMs at an instruction index equal to the parent bytecode length because that is out-of-bounds. 

### Description
- Change the bounds checks in `OpCode::SpawnActor` and `OpCode::SpawnSupervisor` from `*addr > execution.bytecode.len()` to `*addr >= execution.bytecode.len()` in `src/vm/opcodes.rs` so targets equal to `bytecode.len()` are rejected. 
- Add two regression tests in `tests/vm_errors.rs`: `spawn_actor_at_bytecode_len_returns_error` and `spawn_supervisor_at_bytecode_len_returns_error` that assert `VmError::ExecutionOutOfBounds` for `SpawnActor(bytecode.len())` and `SpawnSupervisor(bytecode.len())`. 

### Testing
- Ran `rustfmt --edition 2021 src/vm/opcodes.rs tests/vm_errors.rs` and `git diff --check` successfully. 
- Attempted `cargo test` for the VM error tests but test execution was blocked because the workspace has an existing parse error in `src/compiler.rs` (unclosed delimiter), so the added tests could not be run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1f791f148328bdf9f1e2f40b06d9)