### PR TITLE
Restore execution mailbox API

### DIFF
--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::compiler::DebugInfo;
 use crate::vm::error::VmError;
 use crate::vm::heap::Heap;
-use crate::vm::opcodes::Bytecode;
+use crate::vm::opcodes::{Bytecode, OpCode};
 use crate::vm::value::Value;
 
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -43,6 +43,7 @@ pub struct ExecutionContext {
     pub call_stack: Vec<usize>,
     pub bytecode: Vec<OpCode>,
     pub debug_info: Option<DebugInfo>,
+    pub mailbox: Receiver<Value>,
 }
 
 impl ExecutionContext {
@@ -52,6 +53,8 @@ impl ExecutionContext {
     }
 
     pub fn with_mailbox(bytecode: impl Into<Bytecode>, mailbox: Receiver<Value>) -> Self {
+        let bytecode = Self::decode_bytecode(bytecode);
+
         Self {
             stack: Vec::new(),
             locals: HashMap::new(),
@@ -60,19 +63,22 @@ impl ExecutionContext {
             call_stack: Vec::new(),
             bytecode,
             debug_info: None,
+            mailbox,
         }
     }
 
     pub fn new_with_debug(bytecode: Vec<OpCode>, debug_info: Option<DebugInfo>) -> Self {
-        Self {
-            stack: Vec::new(),
-            locals: HashMap::new(),
-            globals: HashMap::new(),
-            ip: 0,
-            call_stack: Vec::new(),
-            bytecode,
-            debug_info,
-        }
+        let (_tx, rx) = tokio::sync::mpsc::channel(100);
+        let mut execution = Self::with_mailbox(bytecode, rx);
+        execution.debug_info = debug_info;
+        execution
+    }
+
+    fn decode_bytecode(bytecode: impl Into<Bytecode>) -> Vec<OpCode> {
+        let bytecode = bytecode.into();
+        (0..bytecode.len())
+            .map(|ip| bytecode.decode(ip).expect("encoded bytecode should decode"))
+            .collect()
     }
 
     pub fn step(&mut self, heap: &mut Heap) -> Result<ExecutionState, VmError> {
@@ -115,8 +121,7 @@ impl ExecutionContext {
         self.ip += 1;
         log::info!("Executing opcode: {:?}", opcode);
         opcode
-            .execute_with_process(self, heap, mailbox, process)
-            .await
+            .execute_with_process(self, heap, process)
             .map_err(|error| self.with_debug_location(error, instruction_ip))
     }
 
@@ -160,5 +165,9 @@ impl ExecutionContext {
 
     pub fn globals_mut(&mut self) -> &mut HashMap<String, Value> {
         &mut self.globals
+    }
+
+    pub fn mailbox_mut(&mut self) -> &mut Receiver<Value> {
+        &mut self.mailbox
     }
 }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -5,7 +5,7 @@ use crate::stdlib;
 use crate::vm::error::VmError;
 use crate::vm::execution::{BlockingOperation, ExecutionContext, ExecutionState};
 use crate::vm::heap::{Heap, HeapObject};
-use crate::vm::opcodes::Bytecode;
+use crate::vm::opcodes::{Bytecode, OpCode};
 use crate::vm::supervision::{
     ChildSpec, ExitReason, ExitSignal, SupervisorState, SupervisorStrategy,
 };
@@ -41,9 +41,10 @@ impl VM {
         supervisor: Option<Sender<usize>>,
     ) -> (Self, Sender<Value>) {
         let (tx, rx) = mpsc::channel(100);
-        let bytecode = bytecode.into();
+        let bytecode: Bytecode = bytecode.into();
         log::info!("Initializing VM with {} opcodes", bytecode.len());
-        let mut execution = ExecutionContext::new_with_debug(bytecode, debug_info);
+        let mut execution = ExecutionContext::with_mailbox(bytecode, rx);
+        execution.debug_info = debug_info;
         let mut heap = Heap::new();
         stdlib::install(&mut heap, &mut execution);
 


### PR DESCRIPTION
### Motivation
- Reintroduce the mailbox receiver on `ExecutionContext` so opcodes and runtime can access an actor mailbox directly and restore the previous synchronous opcode execution path.
- Ensure VM construction wires its sender/receiver pair into the execution context so `Actor` and `VM` mailbox APIs remain usable.

### Description
- Import `OpCode` alongside `Bytecode` and add `pub mailbox: Receiver<Value>` to `ExecutionContext` in `src/vm/execution.rs`.
- Add `ExecutionContext::with_mailbox(bytecode, mailbox)` and update `new_with_debug` to delegate to `with_mailbox` by creating a fresh channel, plus add `decode_bytecode` helper to materialize `Vec<OpCode>` from `Bytecode`.
- Add `pub fn mailbox_mut(&mut self) -> &mut Receiver<Value>` to `ExecutionContext` and update `step_inner` to call `opcode.execute_with_process(self, heap, process)` synchronously (removed mailbox argument and `.await`).
- Update `VM::new_with_debug` in `src/vm/vm.rs` to create a channel and initialize the `ExecutionContext` via `with_mailbox(rx)`, and adjust imports to use `crate::vm::opcodes::{Bytecode, OpCode}`.

### Testing
- Ran `rustfmt`/`rustfmt --edition 2021` on the modified files which succeeded. (`rustfmt` was executed as part of the edit workflow.)
- Ran a workspace syntax/format check with `git diff --check` which reported no issues for the changed files.
- Ran `cargo check` which could not complete because of an existing unrelated parse error in `src/compiler.rs` (an unclosed delimiter), so full type-checking of these changes was blocked by that existing compiler error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1f72a11c832889cefdab1acfeb86)