### PR TITLE
Release retained messages on send failures

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -943,6 +943,7 @@ impl OpCode {
                         }
                         Err(TrySendError::Closed(message)) => {
                             push_value(execution, heap, Value::Reference(address))?;
+                            release_value(heap, message)?;
                             Err(VmError::ChannelSend {
                                 error: "channel closed".to_string(),
                                 value: message,

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -184,6 +184,7 @@ impl VM {
                     let error = err.to_string();
                     let value = err.0;
                     self.push_runtime_value(Value::Reference(actor_address))?;
+                    self.release_runtime_value(value)?;
                     Err(VmError::ChannelSend { error, value })
                 }
             },
@@ -195,6 +196,13 @@ impl VM {
             self.increment_reference(address)?;
         }
         self.execution.stack.push(value);
+        Ok(())
+    }
+
+    fn release_runtime_value(&mut self, value: Value) -> Result<(), VmError> {
+        if let Value::Reference(address) = value {
+            self.decrement_reference(address)?;
+        }
         Ok(())
     }
 
@@ -477,5 +485,59 @@ mod tests {
         } else {
             panic!("Expected HeapObject::Actor");
         }
+    }
+
+    #[tokio::test]
+    async fn blocking_send_failure_releases_retained_message_reference() {
+        use crate::vm::error::VmError;
+        use crate::vm::HeapObject;
+
+        let (mut vm, _tx) = VM::new(vec![OpCode::Return], None);
+        let (sender, receiver) = mpsc::channel(1);
+        drop(receiver);
+
+        let (actor_vm, actor_sender) = VM::new(vec![OpCode::Return], None);
+        let actor_addr = vm
+            .heap
+            .allocate(HeapObject::Actor(actor_vm, actor_sender, 0));
+        let message_addr = vm.heap.allocate(HeapObject::Array(vec![], 0));
+
+        if let Some(HeapObject::Array(_, rc)) = vm.heap.get_mut(message_addr) {
+            *rc = 1;
+        } else {
+            panic!("Expected message array");
+        }
+
+        let err = vm
+            .await_blocking_operation(BlockingOperation::SendMessage {
+                sender,
+                actor_address: actor_addr,
+                message: Value::Reference(message_addr),
+            })
+            .await
+            .expect_err("closed blocking send should fail");
+
+        match err {
+            VmError::ChannelSend { value, .. } => {
+                assert_eq!(value, Value::Reference(message_addr));
+            }
+            other => panic!("Expected ChannelSend error, got {other:?}"),
+        }
+
+        assert_eq!(
+            vm.execution.stack,
+            vec![Value::Reference(actor_addr)],
+            "actor reference should be restored on blocking send failure",
+        );
+        assert_eq!(
+            vm.heap_ref_count(actor_addr),
+            Some(1),
+            "actor reference count should stay on stack after blocking send failure",
+        );
+        assert_eq!(
+            vm.heap_ref_count(message_addr),
+            Some(0),
+            "blocking send failure should release retained message reference",
+        );
     }
 }

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -148,8 +148,8 @@ async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
     {
         HeapObject::Array(_, rc) => {
             assert_eq!(
-                *rc, 1,
-                "failed_message in ChannelSend should own exactly one reference",
+                *rc, 0,
+                "failed send should release the retained message reference",
             )
         }
         other => panic!("expected array at message_addr, got {other:?}"),


### PR DESCRIPTION
### Motivation
- Ensure that when a message is retained for sending but the send fails (channel closed), the retained message reference is released to avoid leaking heap references. 
- Preserve the documented stack-stable behavior for actor references so the actor reference remains on the stack after both immediate and awaited send failures. 

### Description
- In `src/vm/opcodes.rs` the `OpCode::SendMessage` closed-channel path now calls `release_value(heap, message)` after restoring the actor reference to the stack and before returning `VmError::ChannelSend`. 
- In `src/vm/vm.rs` the `await_blocking_operation` path for `BlockingOperation::SendMessage` now restores the actor reference via `push_runtime_value(Value::Reference(actor_address))` and then releases the retained message with a new helper `fn release_runtime_value(&mut self, value: Value)`. 
- Updated `tests/vm_errors.rs` to expect the retained message reference is released on a failed immediate send. 
- Added a new test `blocking_send_failure_releases_retained_message_reference` (in `src/vm/vm.rs` tests) that verifies actor-reference stack stability and that the retained message reference is released after a failed awaited send. 

### Testing
- Ran formatting check with `rustfmt --edition 2021 --check src/vm/opcodes.rs src/vm/vm.rs tests/vm_errors.rs`, which succeeded. 
- Attempted to run `cargo test`, but the test run failed to complete due to a pre-existing parse error (unrelated to these changes) in `src/compiler.rs` that prevents the test suite from building. 
- `git diff --check` and local formatting checks were used to validate the changes compiled into the modified files (no formatting issues in the edited files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1f7a51188328b09984e5f6cf5d94)