### PR TITLE
Handle integer arithmetic overflow

### DIFF
--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -19,6 +19,8 @@ pub enum VmError {
     StackUnderflowFor(&'static str),
     #[error("Type mismatch in {0}")]
     TypeMismatch(&'static str),
+    #[error("Integer overflow")]
+    IntegerOverflow,
     #[error("Division by zero")]
     DivisionByZero,
     #[error("Execution out of bounds")]

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -710,7 +710,9 @@ impl OpCode {
             OpCode::Mul => binary_op(execution, heap, |a, b| a.checked_mul(b)),
             OpCode::Div => binary_op(execution, heap, |a, b| a.checked_div(b)),
             OpCode::Neg => unary_op(execution, heap, |a| match a {
-                Value::Integer(i) => Ok(Value::Integer(-i)),
+                Value::Integer(i) => i32::checked_neg(i)
+                    .map(Value::Integer)
+                    .ok_or(VmError::IntegerOverflow),
                 Value::Float(f) => Ok(Value::Float(-f)),
                 _ => Err(VmError::TypeMismatch("Neg")),
             }),
@@ -800,7 +802,9 @@ impl OpCode {
                     if y < 0 {
                         Ok(Value::Float((x as f64).powi(y)))
                     } else {
-                        Ok(Value::Integer(x.pow(y as u32)))
+                        i32::checked_pow(x, y as u32)
+                            .map(Value::Integer)
+                            .ok_or(VmError::IntegerOverflow)
                     }
                 }
                 (Value::Float(x), Value::Float(y)) => Ok(Value::Float(x.powf(y))),

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -18,7 +18,9 @@ pub enum Value {
 impl Value {
     pub fn checked_add(self, other: Value) -> Result<Value, VmError> {
         match (self, other) {
-            (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a + b)),
+            (Value::Integer(a), Value::Integer(b)) => i32::checked_add(a, b)
+                .map(Value::Integer)
+                .ok_or(VmError::IntegerOverflow),
             (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a + b)),
             _ => Err(VmError::TypeMismatch("Add")),
         }
@@ -26,7 +28,9 @@ impl Value {
 
     pub fn checked_sub(self, other: Value) -> Result<Value, VmError> {
         match (self, other) {
-            (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a - b)),
+            (Value::Integer(a), Value::Integer(b)) => i32::checked_sub(a, b)
+                .map(Value::Integer)
+                .ok_or(VmError::IntegerOverflow),
             (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a - b)),
             _ => Err(VmError::TypeMismatch("Sub")),
         }
@@ -34,7 +38,9 @@ impl Value {
 
     pub fn checked_mul(self, other: Value) -> Result<Value, VmError> {
         match (self, other) {
-            (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a * b)),
+            (Value::Integer(a), Value::Integer(b)) => i32::checked_mul(a, b)
+                .map(Value::Integer)
+                .ok_or(VmError::IntegerOverflow),
             (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a * b)),
             _ => Err(VmError::TypeMismatch("Mul")),
         }

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -15,6 +15,72 @@ async fn division_by_zero_returns_error() {
 }
 
 #[tokio::test]
+async fn integer_add_overflow_returns_error() {
+    let code = vec![
+        OpCode::PushConst(Value::Integer(i32::MAX)),
+        OpCode::PushConst(Value::Integer(1)),
+        OpCode::Add,
+    ];
+    let (mut vm, _tx) = VM::new(code, None);
+
+    let err = vm.run().await.expect_err("expected integer overflow");
+
+    assert!(matches!(err, VmError::IntegerOverflow));
+}
+
+#[tokio::test]
+async fn integer_sub_overflow_returns_error() {
+    let code = vec![
+        OpCode::PushConst(Value::Integer(i32::MIN)),
+        OpCode::PushConst(Value::Integer(1)),
+        OpCode::Sub,
+    ];
+    let (mut vm, _tx) = VM::new(code, None);
+
+    let err = vm.run().await.expect_err("expected integer overflow");
+
+    assert!(matches!(err, VmError::IntegerOverflow));
+}
+
+#[tokio::test]
+async fn integer_mul_overflow_returns_error() {
+    let code = vec![
+        OpCode::PushConst(Value::Integer(i32::MAX)),
+        OpCode::PushConst(Value::Integer(2)),
+        OpCode::Mul,
+    ];
+    let (mut vm, _tx) = VM::new(code, None);
+
+    let err = vm.run().await.expect_err("expected integer overflow");
+
+    assert!(matches!(err, VmError::IntegerOverflow));
+}
+
+#[tokio::test]
+async fn integer_neg_overflow_returns_error() {
+    let code = vec![OpCode::PushConst(Value::Integer(i32::MIN)), OpCode::Neg];
+    let (mut vm, _tx) = VM::new(code, None);
+
+    let err = vm.run().await.expect_err("expected integer overflow");
+
+    assert!(matches!(err, VmError::IntegerOverflow));
+}
+
+#[tokio::test]
+async fn integer_exp_overflow_returns_error() {
+    let code = vec![
+        OpCode::PushConst(Value::Integer(i32::MAX)),
+        OpCode::PushConst(Value::Integer(2)),
+        OpCode::Exp,
+    ];
+    let (mut vm, _tx) = VM::new(code, None);
+
+    let err = vm.run().await.expect_err("expected integer overflow");
+
+    assert!(matches!(err, VmError::IntegerOverflow));
+}
+
+#[tokio::test]
 async fn pop_on_empty_stack_returns_error() {
     let code = vec![OpCode::Pop];
     let (mut vm, _tx) = VM::new(code, None);


### PR DESCRIPTION
### Motivation
- Prevent silent integer wraparound by surfacing overflows as VM runtime errors instead of returning wrong values.
- Ensure arithmetic in both `Value` helpers and opcode implementations uses the same checked semantics.
- Add regression tests for boundary overflow cases to avoid regressions.

### Description
- Add a new `VmError::IntegerOverflow` variant in `src/vm/error.rs`.
- Replace direct integer `+`, `-`, and `*` in `Value::checked_add`, `Value::checked_sub`, and `Value::checked_mul` with `i32::checked_add`, `i32::checked_sub`, and `i32::checked_mul` that return `VmError::IntegerOverflow` on overflow (in `src/vm/value.rs`).
- Update `OpCode::Neg` to use `i32::checked_neg` and the integer branch of `OpCode::Exp` to use `i32::checked_pow`, returning `VmError::IntegerOverflow` when the checked operations fail (in `src/vm/opcodes.rs`).
- Add tests to `tests/vm_errors.rs` for `i32::MAX + 1`, `i32::MIN - 1`, `i32::MAX * 2`, `Neg i32::MIN`, and overflowing integer exponentiation.

### Testing
- Ran `rustfmt --edition 2021 --check src/vm/error.rs src/vm/value.rs src/vm/opcodes.rs tests/vm_errors.rs` which passed.
- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Ran `cargo test` but the test run failed to complete due to an unrelated parse error in `src/compiler.rs` (unclosed delimiter), so the new tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1f7e27008328ac6be0684d9048af)