### PR TITLE
Add instruction reduction quota with cooperative yielding in VM

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 static NEXT_PROCESS_ID: AtomicUsize = AtomicUsize::new(1);
+const REDUCTION_QUOTA: usize = 2_000;
 
 #[derive(Debug)]
 pub struct VM {
@@ -26,6 +27,7 @@ pub struct VM {
     restart_ip: usize,
     links: Vec<Sender<Value>>,
     trap_exits: bool,
+    reductions: usize,
     supervisor_state: SupervisorState,
     _supervisor: Option<Sender<usize>>,
 }
@@ -58,6 +60,7 @@ impl VM {
                 restart_ip: 0,
                 links: Vec::new(),
                 trap_exits: false,
+                reductions: 0,
                 supervisor_state: SupervisorState::default(),
                 _supervisor: supervisor,
             },
@@ -137,9 +140,16 @@ impl VM {
             );
 
             match state {
-                Ok(ExecutionState::Continue) => {}
+                Ok(ExecutionState::Continue) => {
+                    self.reductions += 1;
+                    if self.reductions >= REDUCTION_QUOTA {
+                        self.reductions = 0;
+                        tokio::task::yield_now().await;
+                    }
+                }
                 Ok(ExecutionState::Halted) => break,
                 Ok(ExecutionState::Yield(operation)) => {
+                    self.reductions = 0;
                     if let Err(e) = self.await_blocking_operation(operation).await {
                         log::error!("Execution error at ip {}: {}", self.execution.ip, e);
                         self.notify_links(&e).await;


### PR DESCRIPTION
### Motivation
- Prevent a single VM process from monopolizing a Tokio worker thread by adding cooperative preemption for tight bytecode loops.
- Enforce a per-process instruction quota so long-running or malicious bytecode yields to the scheduler periodically.

### Description
- Added a constant `REDUCTION_QUOTA: usize = 2_000` to define the instruction quota. (`src/vm/vm.rs`)
- Added a `reductions: usize` field to `VM` to track executed instructions between yields. (`src/vm/vm.rs`)
- In `VM::run()`, increment `reductions` on each `ExecutionState::Continue` and call `tokio::task::yield_now().await` when the quota is reached, then reset the counter. (`src/vm/vm.rs`)
- Reset `reductions` when execution reaches an explicit `ExecutionState::Yield` so natural async blocking still behaves normally. (`src/vm/vm.rs`)

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test` which failed to build due to unrelated/pre-existing compile errors in `src/vm/execution.rs`, `src/vm/heap.rs`, and `src/vm/opcodes.rs` (duplicate field/method declarations and some type/signature mismatches), so no test suite results are available for this change alone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f02294dc08328902665fab617ae5e)