### PR TITLE
Refactor heap reclamation toward per-actor arena lifecycle

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -222,98 +222,56 @@ impl Heap {
     }
 
     pub fn collect_garbage(&mut self) {
-        let before = self.live_count();
-        let live = self.trace_live_objects();
-        self.sweep_unmarked(&live);
-        let collected = before - self.live_count();
-        if collected > 0 {
-            log::info!("Collected {} unreachable heap objects", collected);
+        let mut reclaimed = 0usize;
+        for address in 0..self.objects.len() {
+            if self.try_release(address) {
+                reclaimed += 1;
+            }
+        }
+        if reclaimed > 0 {
+            log::info!("Reclaimed {} zero-ref heap objects", reclaimed);
         }
     }
 
-    fn live_count(&self) -> usize {
-        self.objects
-            .iter()
-            .filter(|object| object.is_some())
-            .count()
-    }
-
-    fn trace_live_objects(&self) -> Vec<bool> {
-        let internal_references = self.internal_reference_counts();
-        let mut live = vec![false; self.objects.len()];
-        let mut worklist = Vec::new();
-
-        for (address, object) in self.objects.iter().enumerate() {
-            let Some(object) = object else {
-                continue;
-            };
-
-            let ref_count = object.ref_count();
-            if ref_count > internal_references[address] {
-                live[address] = true;
-                worklist.push(address);
-            }
-        }
-
-        while let Some(address) = worklist.pop() {
-            let Some(object) = self.get(address) else {
-                continue;
-            };
-
-            for referenced_address in object.references() {
-                if referenced_address < live.len()
-                    && self.objects[referenced_address].is_some()
-                    && !live[referenced_address]
-                {
-                    live[referenced_address] = true;
-                    worklist.push(referenced_address);
-                }
-            }
-        }
-
-        live
-    }
-
-    fn internal_reference_counts(&self) -> Vec<usize> {
-        let mut counts = vec![0; self.objects.len()];
-        for object in self.objects.iter().flatten() {
-            for referenced_address in object.references() {
-                if let Some(count) = counts.get_mut(referenced_address) {
-                    *count += 1;
-                }
-            }
-        }
-        counts
-    }
-
-    fn sweep_unmarked(&mut self, live: &[bool]) {
-        let mut references_to_release = Vec::new();
-        let mut addresses_to_free = Vec::new();
-
-        for (address, object) in self.objects.iter().enumerate() {
-            let Some(object) = object else {
-                continue;
-            };
-
-            if !live.get(address).copied().unwrap_or(false) {
-                references_to_release.extend(object.references().into_iter().filter(
-                    |referenced_address| live.get(*referenced_address).copied().unwrap_or(false),
-                ));
-                addresses_to_free.push(address);
-            }
-        }
-
-        for referenced_address in references_to_release {
-            if let Some(object) = self.get_mut(referenced_address) {
+    pub fn release_reference(&mut self, address: usize) -> Result<(), VmError> {
+        let child_references = match self.get_mut(address) {
+            Some(object) => {
+                let refs = if object.ref_count() == 1 {
+                    object.references()
+                } else {
+                    Vec::new()
+                };
                 object.decrement_ref();
+                refs
             }
+            None => return Err(VmError::InvalidReference),
+        };
+
+        for child in child_references {
+            self.release_reference(child)?;
+        }
+        let _ = self.try_release(address);
+        Ok(())
+    }
+
+    fn try_release(&mut self, address: usize) -> bool {
+        let should_release = matches!(self.objects.get(address), Some(Some(object)) if object.ref_count() == 0);
+        if !should_release {
+            return false;
         }
 
-        for address in addresses_to_free {
-            if self.objects[address].take().is_some() {
-                self.free_list.push(address);
-            }
+        let child_references = self
+            .objects
+            .get(address)
+            .and_then(|object| object.as_ref())
+            .map(|object| object.references())
+            .unwrap_or_default();
+        self.objects[address] = None;
+        self.free_list.push(address);
+        for child in child_references {
+            let _ = self.release_reference(child);
         }
+        true
     }
 }
 

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -60,7 +60,7 @@ fn decrement_reference(heap: &mut Heap, address: usize) -> Result<(), VmError> {
 
     for value in child_references {
         if let Value::Reference(child_address) = value {
-            decrement_reference(heap, child_address)?;
+            heap.release_reference(child_address)?;
         }
     }
 
@@ -177,7 +177,7 @@ fn push_value(
 fn pop_value(execution: &mut ExecutionContext, heap: &mut Heap) -> Result<Value, VmError> {
     if let Some(value) = execution.stack.pop() {
         if let Value::Reference(address) = value {
-            decrement_reference(heap, address)?;
+            heap.release_reference(address)?;
         }
         Ok(value)
     } else {
@@ -201,7 +201,7 @@ fn retain_value(heap: &mut Heap, value: Value) -> Result<(), VmError> {
 
 fn release_value(heap: &mut Heap, value: Value) -> Result<(), VmError> {
     if let Value::Reference(address) = value {
-        decrement_reference(heap, address)?;
+        heap.release_reference(address)?;
     }
     Ok(())
 }
@@ -811,7 +811,7 @@ impl OpCode {
                 let value = pop_value(execution, heap)?;
 
                 if let Some(Value::Reference(address)) = execution.locals.insert(*index, value) {
-                    decrement_reference(heap, address)?;
+                    heap.release_reference(address)?;
                 }
 
                 if let Value::Reference(address) = value {
@@ -956,7 +956,7 @@ impl OpCode {
                 Ok(message) => {
                     log::info!("Received message: {:?}", message);
                     if let Value::Reference(address) = message {
-                        decrement_reference(heap, address)?;
+                        heap.release_reference(address)?;
                     }
                     push_value(execution, heap, message)
                 }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -218,8 +218,7 @@ impl VM {
 
     fn decrement_reference(&mut self, address: usize) -> Result<(), VmError> {
         if let Some(object) = self.heap.get_mut(address) {
-            object.decrement_ref();
-            Ok(())
+            self.heap.release_reference(address)
         } else {
             Err(VmError::InvalidReference)
         }


### PR DESCRIPTION
### Motivation
- Reduce reliance on a global mark-and-sweep GC and move toward per-actor arena semantics by reclaiming memory at reference-drop time so actor teardown can free whole object graphs without global sweep phases. 

### Description
- Replace the global mark/sweep pass in `Heap::collect_garbage` with an immediate zero-ref reclamation loop that calls an internal `try_release` helper. 
- Add `Heap::release_reference` which recursively drops references from an object when its ref-count transitions and delegates final freeing to `try_release`. 
- Add `try_release` to free a heap slot and cascade releases for its children when the object's ref-count reaches zero. 
- Update opcode and VM reference-release call sites to use `heap.release_reference(...)` (used from `pop_value`, `release_value`, local stores, receive/send flows and the VM decrement path) so reclamation occurs at the moment references are dropped.

### Testing
- Ran `cargo test -q` to validate the change set and build the test suite. 
- The test run failed to compile with multiple compiler errors, including duplicate `mailbox` field/method definitions in `src/vm/execution.rs`, a missing `decode_bytecode` associated function, type mismatches between `Bytecode` and `Vec<OpCode>`, and other compilation errors observed during the run. 
- These compiler errors prevented running the automated tests to completion (no failing runtime tests were observed because compilation did not succeed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f021c192c83288279ecf9a3ee23c2)