### PR TITLE
Atomically replace process runtime on actor restart (task, IP, mailbox)

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -122,13 +122,21 @@ impl ProcessHandle {
         self.trap_exits
     }
 
-    pub fn replace_task(&mut self, task: JoinHandle<Result<(), VmError>>, start_ip: usize) {
+    pub fn replace_runtime(
+        &mut self,
+        task: JoinHandle<Result<(), VmError>>,
+        start_ip: usize,
+        mailbox: Receiver<Value>,
+        mailbox_sender: Sender<Value>,
+    ) {
         if let Some(task) = &self.task {
             task.abort();
         }
         self.task = Some(task);
         self.start_ip = start_ip;
         self.current_ip = start_ip;
+        self.mailbox = mailbox;
+        self.mailbox_sender = mailbox_sender;
     }
 
     pub async fn run(&mut self) -> Result<(), VmError> {
@@ -255,7 +263,8 @@ impl Heap {
     }
 
     fn try_release(&mut self, address: usize) -> bool {
-        let should_release = matches!(self.objects.get(address), Some(Some(object)) if object.ref_count() == 0);
+        let should_release =
+            matches!(self.objects.get(address), Some(Some(object)) if object.ref_count() == 0);
         if !should_release {
             return false;
         }

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -148,9 +148,15 @@ fn restart_actor(heap: &mut Heap, child: ChildSpec) -> Result<(), VmError> {
             for link in process.links() {
                 vm.link(link);
             }
-            *sender = replacement_tx;
+            let replacement_mailbox = vm.take_mailbox();
+            *sender = replacement_tx.clone();
             let final_stack = Arc::new(Mutex::new(Vec::new()));
-            process.replace_task(run_process(vm, final_stack.clone()), child.start_ip);
+            process.replace_runtime(
+                run_process(vm, final_stack.clone()),
+                child.start_ip,
+                replacement_mailbox,
+                replacement_tx,
+            );
             log::info!(
                 "Restarted actor {} at ip {}",
                 child.reference,

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -123,6 +123,11 @@ impl VM {
         self.restart_ip = ip;
     }
 
+    pub fn take_mailbox(&mut self) -> Receiver<Value> {
+        let (_tx, replacement_mailbox) = mpsc::channel(1);
+        std::mem::replace(self.execution.mailbox_mut(), replacement_mailbox)
+    }
+
     pub async fn run(&mut self) -> Result<(), VmError> {
         if self.execution.bytecode.is_empty() {
             log::warn!("Attempted to run VM with empty bytecode");


### PR DESCRIPTION
### Motivation
- Ensure actor restarts swap all restart-sensitive runtime state (task handle, start/current IP, mailbox receiver/sender) atomically so mailbox accessors always point at the active runtime after a restart and supervision restart strategies (including one-for-all) behave correctly.

### Description
- Add `ProcessHandle::replace_runtime(...)` to atomically replace the task `JoinHandle`, `start_ip`/`current_ip`, mailbox `Receiver`, and mailbox `Sender` in the stored process handle (`src/vm/heap.rs`).
- Update `restart_actor` (`src/vm/opcodes.rs`) to obtain the replacement VM mailbox via `VM::take_mailbox()` and pass the mailbox receiver and sender into `replace_runtime`, and update the heap-level sender to the replacement sender.
- Add `VM::take_mailbox()` (`src/vm/vm.rs`) to move the `ExecutionContext` mailbox receiver out of the replacement VM so it can be installed into the `ProcessHandle` before launching the restarted task.
- Small formatting/whitespace adjustments in `try_release` matching the local style changes.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo test --test supervision` which failed to build due to pre-existing compile/type issues in `src/vm/execution.rs` and unrelated type mismatches elsewhere, so supervision tests could not be validated end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f08c4fd648328a72a3fa47c65b14c)