### PR TITLE
Fix duplicate mailbox definitions in ExecutionContext

### DIFF
--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -39,7 +39,6 @@ pub struct ExecutionContext {
     pub stack: Vec<Value>,
     pub locals: HashMap<usize, Value>,
     pub globals: HashMap<String, Value>,
-    mailbox: Receiver<Value>,
     pub ip: usize,
     pub call_stack: Vec<usize>,
     pub bytecode: Bytecode,
@@ -60,7 +59,6 @@ impl ExecutionContext {
             stack: Vec::new(),
             locals: HashMap::new(),
             globals: HashMap::new(),
-            mailbox,
             ip: 0,
             call_stack: Vec::new(),
             bytecode: bytecode.into(),
@@ -83,7 +81,6 @@ impl ExecutionContext {
             stack: Vec::new(),
             locals: HashMap::new(),
             globals: HashMap::new(),
-            mailbox,
             ip: 0,
             call_stack: Vec::new(),
             bytecode: bytecode.into(),
@@ -182,7 +179,4 @@ impl ExecutionContext {
         &mut self.globals
     }
 
-    pub fn mailbox_mut(&mut self) -> &mut Receiver<Value> {
-        &mut self.mailbox
-    }
 }


### PR DESCRIPTION
### Motivation
- Remove duplicate `mailbox` declarations and duplicate accessor to eliminate conflicting members in `ExecutionContext` and ensure the struct and its constructors are unambiguous.

### Description
- Deleted the duplicated `mailbox: Receiver<Value>` field, removed the duplicated `pub fn mailbox_mut(&mut self) -> &mut Receiver<Value>` method, and updated `with_mailbox` and `with_mailbox_and_debug` to initialize `mailbox` only once in each struct literal.

### Testing
- Ran targeted `rg` searches to verify there is a single `mailbox` field and a single `mailbox_mut` method and confirmed call sites in `src/vm/vm.rs` and `src/vm/opcodes.rs` still use the same `mailbox_mut(&mut self) -> &mut Receiver<Value>` signature (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f08c5285c832887c1001d7daec5cc)