### PR TITLE
Handle CLI help/prompt IO errors without unwrap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,10 @@ async fn main() {
 }
 
 fn print_help() {
-    Cli::command().print_long_help().unwrap();
+    if let Err(e) = Cli::command().print_long_help() {
+        eprintln!("Failed to print help: {}", e);
+        process::exit(1);
+    }
     println!();
 }
 
@@ -93,7 +96,10 @@ async fn start_repl() {
         } else {
             print!("...> ");
         }
-        std::io::stdout().flush().unwrap();
+        if let Err(e) = std::io::stdout().flush() {
+            eprintln!("Output error: {}", e);
+            break;
+        }
         input.clear();
 
         if let Err(e) = reader.read_line(&mut input).await {


### PR DESCRIPTION
### Motivation
- Prevent panics in user-facing CLI paths by handling I/O errors explicitly when printing help and flushing REPL prompts.

### Description
- Replaced `Cli::command().print_long_help().unwrap()` with explicit error handling that prints a concise stderr message and exits with status 1 on failure while preserving successful help output.
- Replaced `std::io::stdout().flush().unwrap()` in the REPL loop with `if let Err(e) = ... { eprintln!("Output error: {}", e); break; }` to avoid panics on flush failures and to take a controlled path.
- Confirmed no remaining `unwrap()` calls exist in `src/main.rs` and retained the same prompt and help text for successful flows.

### Testing
- Searched for `unwrap(` in `src/main.rs` using `rg` and found no matches (success).
- Ran `cargo check -q`, which failed due to pre-existing compile errors in other modules, so the repo build did not succeed (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f08c6cc288328bb5f904e02bb1fdf)