### PR TITLE
Remove redundant VM initialization during SpawnActor/SpawnSupervisor

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -976,8 +976,6 @@ impl OpCode {
             },
 
             OpCode::SpawnActor(addr) => {
-                let bytecode = execution.bytecode.clone();
-                let (mut vm, tx) = VM::new_with_debug(bytecode, execution.debug_info.clone(), None);
                 if *addr >= execution.bytecode.len() {
                     log::error!(
                         "SpawnActor target {} out of bounds (bytecode length {})",
@@ -1045,8 +1043,6 @@ impl OpCode {
                 }
             }
             OpCode::SpawnSupervisor(addr) => {
-                let bytecode = execution.bytecode.clone();
-                let (mut vm, tx) = VM::new_with_debug(bytecode, execution.debug_info.clone(), None);
                 if *addr >= execution.bytecode.len() {
                     log::error!(
                         "SpawnSupervisor target {} out of bounds (bytecode length {})",

--- a/tests/supervision.rs
+++ b/tests/supervision.rs
@@ -131,3 +131,55 @@ async fn supervisor_restart_child_uses_one_for_all_strategy() {
         other => panic!("expected second actor, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn spawn_opcodes_allocate_one_process_id_each() {
+    let mut execution = ExecutionContext::new(vec![OpCode::Return]);
+    let mut heap = Heap::new();
+
+    OpCode::SpawnSupervisor(0)
+        .execute(&mut execution, &mut heap)
+        .expect("spawn supervisor should succeed");
+    let supervisor_addr = match execution.stack.pop() {
+        Some(Value::Reference(addr)) => addr,
+        other => panic!("expected supervisor reference, got {other:?}"),
+    };
+
+    let supervisor_pid = match heap.get(supervisor_addr).expect("supervisor should exist") {
+        HeapObject::Supervisor(handle, _, _) => handle.process_id(),
+        other => panic!("expected supervisor, got {other:?}"),
+    };
+
+    OpCode::SpawnActor(0)
+        .execute(&mut execution, &mut heap)
+        .expect("spawn first actor should succeed");
+    let first_actor_addr = match execution.stack.pop() {
+        Some(Value::Reference(addr)) => addr,
+        other => panic!("expected actor reference, got {other:?}"),
+    };
+    let first_actor_pid = match heap
+        .get(first_actor_addr)
+        .expect("first actor should exist")
+    {
+        HeapObject::Actor(handle, _, _) => handle.process_id(),
+        other => panic!("expected actor, got {other:?}"),
+    };
+
+    OpCode::SpawnActor(0)
+        .execute(&mut execution, &mut heap)
+        .expect("spawn second actor should succeed");
+    let second_actor_addr = match execution.stack.pop() {
+        Some(Value::Reference(addr)) => addr,
+        other => panic!("expected actor reference, got {other:?}"),
+    };
+    let second_actor_pid = match heap
+        .get(second_actor_addr)
+        .expect("second actor should exist")
+    {
+        HeapObject::Actor(handle, _, _) => handle.process_id(),
+        other => panic!("expected actor, got {other:?}"),
+    };
+
+    assert_eq!(first_actor_pid, supervisor_pid + 1);
+    assert_eq!(second_actor_pid, first_actor_pid + 1);
+}


### PR DESCRIPTION
### Motivation
- Prevent accidental extra process creation when executing `OpCode::SpawnActor` and `OpCode::SpawnSupervisor` by removing a stray local `VM::new_with_debug(...)` that was never used.
- Ensure `spawn_child_vm(...)` is the single, deterministic path for creating child processes so process-id progression is observable and predictable.
- Re-check imports to make sure no unused items remain after the cleanup.

### Description
- Deleted the unused local `VM::new_with_debug(...)` and its associated cloned `bytecode`/`tx` locals from the `OpCode::SpawnActor` match arm so it now calls only `spawn_child_vm(...)` to create the child process.
- Deleted the unused local `VM::new_with_debug(...)` and its associated cloned locals from the `OpCode::SpawnSupervisor` match arm so it now calls only `spawn_child_vm(...)` to create the supervisor process.
- Re-checked imports in `src/vm/opcodes.rs` and confirmed there are no remaining unused imports introduced by this change.
- Added a new test `spawn_opcodes_allocate_one_process_id_each` in `tests/supervision.rs` that asserts each spawn advances the process id by exactly one, guarding against extraneous VM creation side effects.

### Testing
- Ran `cargo fmt` which completed successfully.
- Added the unit test `spawn_opcodes_allocate_one_process_id_each` in `tests/supervision.rs` to validate deterministic pid progression.
- Ran `cargo test --tests supervision -- --nocapture`, which did not complete due to existing unrelated compile errors reported by the compiler in other modules (for example `src/vm/execution.rs`, `src/vm/heap.rs`, and `src/vm/vm.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0c9900488328b89307f0a05e342c)