### PR TITLE
Add regression test to guard ArrayGet/ArraySet/MakeString bytecode mappings

### DIFF
--- a/tests/bytecode.rs
+++ b/tests/bytecode.rs
@@ -27,3 +27,19 @@ fn push_const_uses_constant_pool_operand() {
         OpCode::PushConst(Value::Integer(42))
     ));
 }
+
+#[test]
+fn array_and_string_adjacent_opcodes_round_trip() {
+    let bytecode = Bytecode::new(vec![
+        OpCode::ArrayGet,
+        OpCode::ArraySet,
+        OpCode::MakeString("hello".to_string()),
+    ]);
+
+    assert!(matches!(bytecode.decode(0).unwrap(), OpCode::ArrayGet));
+    assert!(matches!(bytecode.decode(1).unwrap(), OpCode::ArraySet));
+    assert!(matches!(
+        bytecode.decode(2).unwrap(),
+        OpCode::MakeString(value) if value == "hello"
+    ));
+}


### PR DESCRIPTION
### Motivation
- Add a small regression test to prevent accidental opcode-table drift around the `ArrayGet`/`ArraySet`/`MakeString` region and catch duplicate/missing mappings in `Bytecode::decode`.

### Description
- Added `array_and_string_adjacent_opcodes_round_trip` in `tests/bytecode.rs` which builds `Bytecode::new(vec![OpCode::ArrayGet, OpCode::ArraySet, OpCode::MakeString("hello".to_string())])` and asserts `decode` round-trips each opcode, and scanned `Bytecode::decode` to confirm there was no duplicate `OP_ARRAY_GET` arm so no opcode-table change was required.

### Testing
- Attempted `cargo test --test bytecode`, but the test run could not complete because the workspace currently fails to build due to unrelated pre-existing compile errors (e.g. missing `ExecutionContext::decode_bytecode`, missing `ProcessHandle::heap_references`, and type mismatches between `Vec<OpCode>` and `Bytecode`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0c9aa3dc8328a59a2b53708164f2)