### PR TITLE
Add explicit MailboxDisconnected VM error and map closed-mailbox paths

### DIFF
--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -41,6 +41,8 @@ pub enum VmError {
     NativeArityMismatch { expected: usize, actual: usize },
     #[error("Mailbox empty")]
     MailboxEmpty,
+    #[error("Mailbox disconnected")]
+    MailboxDisconnected,
     #[error("Channel send error: {error}")]
     ChannelSend { error: String, value: Value },
     #[error("Compilation error: {0}")]

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -971,7 +971,7 @@ impl OpCode {
                 }
                 Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
                     log::warn!("Mailbox is closed");
-                    Err(VmError::MailboxEmpty)
+                    Err(VmError::MailboxDisconnected)
                 }
             },
 

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -184,7 +184,7 @@ impl VM {
                     .mailbox_mut()
                     .recv()
                     .await
-                    .ok_or(VmError::MailboxEmpty)?;
+                    .ok_or(VmError::MailboxDisconnected)?;
                 if let Value::Reference(address) = message {
                     self.decrement_reference(address)?;
                 }

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -245,6 +245,20 @@ async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
 }
 
 #[tokio::test]
+async fn receive_message_on_closed_mailbox_returns_disconnected_error() {
+    let code = vec![OpCode::ReceiveMessage];
+    let (mut vm, tx) = VM::new(code, None);
+    drop(tx);
+
+    let err = vm
+        .run()
+        .await
+        .expect_err("expected mailbox disconnected error");
+
+    assert!(matches!(err, VmError::MailboxDisconnected));
+}
+
+#[tokio::test]
 async fn top_level_return_gracefully_halts_vm() {
     let code = vec![OpCode::Return];
     let (mut vm, _tx) = VM::new(code, None);


### PR DESCRIPTION
### Motivation
- Distinguish a closed/disconnected actor mailbox from an empty mailbox so callers can handle a permanently closed channel differently from a transient empty state.
- Ensure the synchronous `try_recv` path and the asynchronous blocking `recv().await` path report the same rationale for a closed mailbox.
- Update tests to assert the specific disconnected/closed condition rather than the generic empty error.

### Description
- Added a new error variant `VmError::MailboxDisconnected` in `src/vm/error.rs` to represent a closed/disconnected mailbox.
- Updated `OpCode::ReceiveMessage` in `src/vm/opcodes.rs` to map `TryRecvError::Disconnected` to `VmError::MailboxDisconnected` while keeping `Empty` as the yield path (`BlockingOperation::ReceiveMessage`).
- Updated the blocking receive path in `VM::await_blocking_operation` in `src/vm/vm.rs` so `.recv().await == None` returns `VmError::MailboxDisconnected` consistently.
- Added a unit test `receive_message_on_closed_mailbox_returns_disconnected_error` in `tests/vm_errors.rs` that drops the mailbox sender and asserts the new `VmError::MailboxDisconnected` is returned.

### Testing
- Ran `cargo test --test vm_errors receive_message_on_closed_mailbox_returns_disconnected_error` to exercise the new test, but the build failed to complete due to unrelated pre-existing compilation errors in the repository.
- Example unrelated compile errors observed were missing `ExecutionContext::decode_bytecode` and type mismatches between `Bytecode` and `Vec<OpCode>`, which prevented the new test from being executed.
- No functional test failures were introduced by the changes themselves (the change is limited to error mapping and a matching test), but the repository must be brought to a successful build state before the new test can be run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0c9ba9908328adebafe2acfe74f9)