### PR TITLE
Fix HeapObject actor/supervisor reference tracing to use ProcessHandle

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -170,6 +170,21 @@ impl ProcessHandle {
         self.mailbox_sender.clone()
     }
 
+    pub fn heap_references(&self) -> Vec<usize> {
+        self.final_stack
+            .lock()
+            .map(|stack| {
+                stack
+                    .iter()
+                    .filter_map(|value| match value {
+                        Value::Reference(address) => Some(*address),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     pub fn set_strategy(&mut self, strategy: usize) {
         let strategy = SupervisorStrategy::from_usize(strategy);
         self.supervisor_state.set_strategy(strategy);
@@ -359,6 +374,7 @@ impl HeapObject {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn gc_preserves_objects_reachable_from_live_actor_vm_stack() {
@@ -367,9 +383,22 @@ mod tests {
         let array_address =
             heap.allocate(HeapObject::Array(vec![Value::Reference(string_address)], 0));
 
-        let (mut actor_vm, actor_sender) = VM::new(Vec::new(), None);
-        actor_vm.push_stack_value_for_test(Value::Reference(array_address));
-        let actor_address = heap.allocate(HeapObject::Actor(actor_vm, actor_sender, 1));
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        let (actor_sender, _actor_mailbox) = tokio::sync::mpsc::channel(1);
+        let final_stack = Arc::new(Mutex::new(vec![Value::Reference(array_address)]));
+        let task = runtime.spawn(async { Ok(()) });
+        let actor = ProcessHandle::new(
+            1,
+            None,
+            0,
+            Vec::new(),
+            None,
+            Vec::new(),
+            false,
+            task,
+            final_stack,
+        );
+        let actor_address = heap.allocate(HeapObject::Actor(actor, actor_sender, 1));
 
         heap.collect_garbage();
 


### PR DESCRIPTION
### Motivation
- The heap GC traced actor/supervisor references by calling `heap_references()` on a `VM`, but the `HeapObject::Actor`/`Supervisor` variants now hold a `ProcessHandle` after a refactor, causing a type/method mismatch and invalid test construction.

### Description
- Add `ProcessHandle::heap_references()` in `src/vm/heap.rs` to expose the execution-root references stored in a process final stack so `HeapObject::references()` can trace actor/supervisor children. 
- Update `HeapObject::references()` to rely on the `ProcessHandle` method for `Actor` and `Supervisor` variants. 
- Replace the unit test construction that previously created a `VM` for an actor with a `ProcessHandle` created via `ProcessHandle::new(...)`, using a real Tokio `Runtime` task and a `final_stack` built from `Arc<Mutex<Vec<Value>>>`. 
- Add the required test imports and wiring to keep the existing GC regression intent that objects reachable from a live process stack are preserved.

### Testing
- Ran `cargo build --all-targets`, which confirmed the original `heap.rs` method-mismatch is resolved but overall build fails due to unrelated compile errors in `src/vm/execution.rs`, `src/vm/opcodes.rs`, and `src/vm/vm.rs` (build failed). 
- Ran `cargo test --lib vm::heap::tests::gc_preserves_objects_reachable_from_live_actor_vm_stack`, which was blocked by the same unrelated compile errors and did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1c91d5f483289a7ede047a273344)