### PR TITLE
Unify actor ProcessHandle mailbox with VM mailbox

### DIFF
--- a/src/vm/execution.rs
+++ b/src/vm/execution.rs
@@ -178,5 +178,4 @@ impl ExecutionContext {
     pub fn globals_mut(&mut self) -> &mut HashMap<String, Value> {
         &mut self.globals
     }
-
 }

--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -66,9 +66,10 @@ impl ProcessHandle {
         links: Vec<Sender<Value>>,
         trap_exits: bool,
         task: JoinHandle<Result<(), VmError>>,
+        mailbox: Receiver<Value>,
+        mailbox_sender: Sender<Value>,
         final_stack: Arc<Mutex<Vec<Value>>>,
     ) -> Self {
-        let (mailbox_sender, mailbox) = tokio::sync::mpsc::channel(1);
         Self {
             process_id,
             parent,

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -117,6 +117,7 @@ fn spawn_child_vm(
         let debug_info = vm.debug_info();
         let links = vm.links();
         let trap_exits = vm.trap_exits();
+        let mailbox = vm.take_mailbox();
         let final_stack = Arc::new(Mutex::new(Vec::new()));
         let task = run_process(vm, final_stack.clone());
         ProcessHandle::new(
@@ -128,6 +129,8 @@ fn spawn_child_vm(
             links,
             trap_exits,
             task,
+            mailbox,
+            tx.clone(),
             final_stack,
         )
     };
@@ -1002,26 +1005,15 @@ impl OpCode {
                 let actor_ref = pop_value(execution, heap)?;
                 let message = pop_value(execution, heap)?;
                 if let Value::Reference(address) = actor_ref {
-                    let (sender, mailbox_closed, compatibility_sender) = match heap.get(address) {
-                        Some(HeapObject::Actor(process, sender, _)) => (
-                            sender.clone(),
-                            process.is_mailbox_closed(),
-                            process.mailbox_sender(),
-                        ),
+                    let sender = match heap.get(address) {
+                        Some(HeapObject::Actor(_, sender, _)) => sender.clone(),
                         _ => return Err(VmError::InvalidReference),
                     };
                     if let Value::Reference(message_address) = message {
                         increment_reference(heap, message_address)?;
                     }
-                    match if mailbox_closed {
-                        Err(TrySendError::Closed(message))
-                    } else {
-                        sender.try_send(message)
-                    } {
-                        Ok(()) => {
-                            let _ = compatibility_sender.try_send(message);
-                            push_value(execution, heap, Value::Reference(address))
-                        }
+                    match sender.try_send(message) {
+                        Ok(()) => push_value(execution, heap, Value::Reference(address)),
                         Err(TrySendError::Full(message)) => {
                             return Ok(ExecutionState::Yield(BlockingOperation::SendMessage {
                                 sender,


### PR DESCRIPTION
### Motivation
- Eliminate the bifurcated mailbox state where the `ProcessHandle` observed a different channel than the running VM prior to restart, which could produce subtle race/heisenbugs. 
- Ensure the handle and runtime share the same mailbox channel from process creation so external pokes via the handle are observed by the running VM.

### Description
- Change `ProcessHandle::new` to accept the runtime `mailbox: Receiver<Value>` and `mailbox_sender: Sender<Value>` instead of allocating an internal compatibility channel. 
- In `spawn_child_vm`, extract the VM mailbox with `vm.take_mailbox()` and pass that mailbox and the VM sender into `ProcessHandle::new` so the handle and VM share the same channel at startup. 
- Simplify `OpCode::SendMessage` to send only via the actor runtime `Sender` and remove the dual-send compatibility path, preserving full/closed handling and yield semantics. 
- Minor formatting cleanup in `src/vm/execution.rs` (no behavioral change).

### Testing
- Ran `cargo fmt` which completed successfully. 
- Ran `cargo test -q` which failed due to existing compile errors unrelated to the mailbox unification (examples: missing `ExecutionContext::decode_bytecode`, unresolved `ProcessHandle::heap_references`, and `Bytecode`/`Vec<OpCode>` type mismatches). 
- Confirmed code compiles up to the point of the shown compile errors; the mailbox change itself is self-consistent and covered by the modified call sites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1c985ed08328abd85a0828a810eb)