### PR TITLE
Improve heap GC to reclaim unreachable reference cycles

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -2,7 +2,7 @@
 
 use crate::vm::error::VmError;
 use crate::vm::value::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
@@ -230,14 +230,80 @@ impl Heap {
     }
 
     pub fn collect_garbage(&mut self) {
-        let mut reclaimed = 0usize;
-        for address in 0..self.objects.len() {
-            if self.try_release(address) {
-                reclaimed += 1;
+        let object_count = self.objects.len();
+        let mut internal_incoming = vec![0usize; object_count];
+
+        for address in 0..object_count {
+            let Some(object) = self.objects[address].as_ref() else {
+                continue;
+            };
+            for child in object.references() {
+                if child < object_count && self.objects[child].is_some() {
+                    internal_incoming[child] += 1;
+                }
             }
         }
+
+        let mut reachable = vec![false; object_count];
+        let mut worklist = VecDeque::new();
+
+        for address in 0..object_count {
+            let Some(object) = self.objects[address].as_ref() else {
+                continue;
+            };
+            let external_incoming = object.ref_count().saturating_sub(internal_incoming[address]);
+            if external_incoming > 0 {
+                reachable[address] = true;
+                worklist.push_back(address);
+            }
+        }
+
+        while let Some(address) = worklist.pop_front() {
+            let Some(object) = self.objects[address].as_ref() else {
+                continue;
+            };
+            for child in object.references() {
+                if child < object_count && self.objects[child].is_some() && !reachable[child] {
+                    reachable[child] = true;
+                    worklist.push_back(child);
+                }
+            }
+        }
+
+        let mut pending_release = VecDeque::new();
+        for address in 0..object_count {
+            if self.objects[address].is_some() && !reachable[address] {
+                pending_release.push_back(address);
+            }
+        }
+
+        let mut reclaimed = 0usize;
+        while let Some(address) = pending_release.pop_front() {
+            if self.try_release(address) {
+                reclaimed += 1;
+                continue;
+            }
+
+            let child_references = self
+                .objects
+                .get(address)
+                .and_then(|object| object.as_ref())
+                .map(|object| object.references())
+                .unwrap_or_default();
+
+            self.objects[address] = None;
+            self.free_list.push(address);
+            reclaimed += 1;
+
+            for child in child_references {
+                if self.release_reference(child).is_ok() && self.try_release(child) {
+                    pending_release.push_back(child);
+                }
+            }
+        }
+
         if reclaimed > 0 {
-            log::info!("Reclaimed {} zero-ref heap objects", reclaimed);
+            log::info!("Reclaimed {} unreachable heap objects", reclaimed);
         }
     }
 


### PR DESCRIPTION
### Motivation

- The existing GC only reclaimed objects with `ref_count == 0` and therefore missed unrooted cycles whose per-object ref counts remained positive. 
- For an actor VM where actors can hold references to each other through messages, unreachable positive-ref cycles must be reclaimed to avoid leaks. 

### Description

- Replaced the simple zero-ref sweep in `collect_garbage` with an unreachable-object collector that computes internal incoming edges and treats objects with external retainers as roots. 
- Performs a graph `BFS`-style mark from externally-retained roots using a `VecDeque` worklist and then reclaims all unmarked objects, releasing child references transitively so downstream zero-ref objects can still be collected. 
- Added `VecDeque` import and updated reclamation logging to `Reclaimed {} unreachable heap objects` in `src/vm/heap.rs`.

### Testing

- Ran `cargo test garbage_collection_collects_unrooted_reference_cycle -- --nocapture`; the new GC code compiled as part of the build but the test run failed because the workspace has unrelated compile errors in `src/vm/execution.rs`, `src/vm/opcodes.rs`, and `src/vm/vm.rs`, preventing the test from completing. 
- No additional automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1caf1e8483289a8537568958c156)