### PR TITLE
Recycle VM process IDs to avoid atomic wraparound

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -12,10 +12,28 @@ use crate::vm::supervision::{
 use crate::vm::value::Value;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{LazyLock, Mutex};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 static NEXT_PROCESS_ID: AtomicUsize = AtomicUsize::new(1);
+static RECYCLED_PROCESS_IDS: LazyLock<Mutex<Vec<usize>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 const REDUCTION_QUOTA: usize = 2_000;
+
+fn allocate_process_id() -> usize {
+    if let Some(process_id) = RECYCLED_PROCESS_IDS
+        .lock()
+        .expect("recycled process id list lock poisoned")
+        .pop()
+    {
+        return process_id;
+    }
+
+    NEXT_PROCESS_ID
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            current.checked_add(1)
+        })
+        .expect("process id space exhausted and no recycled ids available")
+}
 
 #[derive(Debug)]
 pub struct VM {
@@ -55,7 +73,7 @@ impl VM {
                 execution,
                 heap,
                 self_sender: tx.clone(),
-                process_id: NEXT_PROCESS_ID.fetch_add(1, Ordering::Relaxed),
+                process_id: allocate_process_id(),
                 parent: None,
                 restart_ip: 0,
                 links: Vec::new(),
@@ -360,6 +378,15 @@ impl VM {
                 log::warn!("Failed to deliver exit signal: {}", err);
             }
         }
+    }
+}
+
+impl Drop for VM {
+    fn drop(&mut self) {
+        RECYCLED_PROCESS_IDS
+            .lock()
+            .expect("recycled process id list lock poisoned")
+            .push(self.process_id);
     }
 }
 


### PR DESCRIPTION
### Motivation
- The runtime used a global `AtomicUsize` with `fetch_add` for process IDs which monotonically increases and can wrap at `usize::MAX`, making the current scheme unsuitable for long-running/high-churn deployments.
- Reuse of freed process IDs avoids unbounded growth while preserving unique IDs among active VMs.

### Description
- Add a global recycled PID pool `RECYCLED_PROCESS_IDS` backed by `LazyLock<Mutex<Vec<usize>>>` to store freed IDs for reuse.
- Add `allocate_process_id()` which first tries to pop an ID from the recycled pool and otherwise uses `NEXT_PROCESS_ID.fetch_update(... checked_add(...))` to allocate a fresh ID. 
- Replace the one-way `NEXT_PROCESS_ID.fetch_add(1, ...)` allocation with `allocate_process_id()` in VM construction. 
- Implement `Drop` for `VM` to push the `process_id` back into the recycled pool when a VM is dropped.

### Testing
- Ran `cargo test -q`, but the build failed due to pre-existing compile errors unrelated to the PID change, so unit tests could not complete. 
- The failing compile errors include missing/changed `ExecutionContext` API (`decode_bytecode` / `new_with_debug` arity), `ProcessHandle::heap_references` method not found, and type mismatches between `Bytecode` and `Vec<OpCode>`, which are orthogonal to the PID reuse changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1cb67c0c8328856bf84fef80f8f6)