### PR TITLE
vm: remove duplicate heap_references stub

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -111,10 +111,6 @@ impl ProcessHandle {
         self.bytecode.clone()
     }
 
-    pub fn heap_references(&self) -> Vec<usize> {
-        Vec::new()
-    }
-
     pub fn debug_info(&self) -> Option<DebugInfo> {
         self.debug_info.clone()
     }
@@ -175,6 +171,10 @@ impl ProcessHandle {
         self.mailbox_sender.clone()
     }
 
+    /// Returns heap references observed in the process's `final_stack` snapshot.
+    ///
+    /// Known limitation (option 3): this only captures references once the task
+    /// has completed and written its final stack, so in-flight references are not visible.
     pub fn heap_references(&self) -> Vec<usize> {
         self.final_stack
             .lock()


### PR DESCRIPTION
### Motivation
- Remove a redundant no-op `ProcessHandle::heap_references` stub and make it explicit that the retained implementation reads references from `final_stack`, which only sees references after the task completes (Option 3 limitation).

### Description
- Deleted the empty `ProcessHandle::heap_references` implementation in `src/vm/heap.rs` and added a doc comment to the remaining `heap_references` that documents the `final_stack`-snapshot behavior.

### Testing
- Ran `cargo test -q`; the test run failed due to existing compile errors in `src/vm/vm.rs` related to missing `SupervisorStrategy`/`ChildSpec` and `supervisor_state`, which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1f8cc4508328b309b06279e6b994)