### PR TITLE
Remove obsolete VM supervision helper methods

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -309,40 +309,6 @@ impl VM {
         self.trap_exits
     }
 
-    pub fn set_strategy(&mut self, strategy: usize) {
-        let strategy = SupervisorStrategy::from_usize(strategy);
-        self.supervisor_state.set_strategy(strategy);
-        log::info!("Set supervisor strategy to {:?}", strategy);
-    }
-
-    pub fn strategy(&self) -> SupervisorStrategy {
-        self.supervisor_state.strategy()
-    }
-
-    pub fn supervised_children(&self) -> &[ChildSpec] {
-        self.supervisor_state.children()
-    }
-
-    pub fn restart_targets(&mut self, child: ChildSpec) -> Vec<ChildSpec> {
-        self.supervisor_state.restart_targets(child)
-    }
-
-    pub fn restart_child(&mut self, child_ref: usize) {
-        self.supervisor_state.ensure_child(ChildSpec {
-            reference: child_ref,
-            start_ip: 0,
-        });
-        log::info!("Registered child {} for restart", child_ref);
-    }
-
-    pub fn reset_for_restart(&mut self, start_ip: usize) {
-        let bytecode = self.execution.bytecode.clone();
-        let debug_info = self.execution.debug_info.clone();
-        let (_tx, rx) = mpsc::channel(100);
-        self.execution = ExecutionContext::with_mailbox_and_debug(bytecode, rx, debug_info);
-        self.execution.ip = start_ip;
-    }
-
     pub fn mailbox_mut(&mut self) -> &mut Receiver<Value> {
         self.execution.mailbox_mut()
     }


### PR DESCRIPTION
### Motivation
- The VM contained helper APIs that referenced a removed supervision state and were no longer called by live code, leaving stale surface area.
- Removing these methods simplifies `VM` and eliminates references to removed supervisor internals so the type's public API matches current behavior.

### Description
- Deleted the following methods from `impl VM` in `src/vm/vm.rs`: `set_strategy`, `strategy`, `supervised_children`, `restart_targets`, `restart_child`, and `reset_for_restart`.
- Ensured `vm.rs` no longer depends on `SupervisorStrategy`, `SupervisorState`, or `ChildSpec`; only `ExitReason` and `ExitSignal` remain imported and in use for `notify_links`.
- Adjusted the `impl VM` layout so accessors proceed from `trap_exits` directly to mailbox/bytecode/debug/links and `notify_links` without the removed supervision helpers.

### Testing
- Ran `cargo check`, which failed due to a pre-existing, unrelated compiler error: duplicate `heap_references` definitions in `src/vm/heap.rs`.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1f9528ec83289fffd84f5c30256e)