### PR TITLE
Fix mailbox stranding by keeping VM receiver when spawning/restarting actors

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -4,7 +4,7 @@ use crate::vm::error::VmError;
 use crate::vm::value::Value;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 
 use crate::compiler::DebugInfo;
@@ -36,8 +36,6 @@ pub struct ProcessHandle {
     trap_exits: bool,
     supervisor_state: SupervisorState,
     task: Option<JoinHandle<Result<(), VmError>>>,
-    mailbox: Receiver<Value>,
-    mailbox_sender: Sender<Value>,
     final_stack: Arc<Mutex<Vec<Value>>>,
 }
 
@@ -66,8 +64,6 @@ impl ProcessHandle {
         links: Vec<Sender<Value>>,
         trap_exits: bool,
         task: JoinHandle<Result<(), VmError>>,
-        mailbox: Receiver<Value>,
-        mailbox_sender: Sender<Value>,
         final_stack: Arc<Mutex<Vec<Value>>>,
     ) -> Self {
         Self {
@@ -81,8 +77,6 @@ impl ProcessHandle {
             trap_exits,
             supervisor_state: SupervisorState::default(),
             task: Some(task),
-            mailbox,
-            mailbox_sender,
             final_stack,
         }
     }
@@ -127,21 +121,13 @@ impl ProcessHandle {
         self.trap_exits
     }
 
-    pub fn replace_runtime(
-        &mut self,
-        task: JoinHandle<Result<(), VmError>>,
-        start_ip: usize,
-        mailbox: Receiver<Value>,
-        mailbox_sender: Sender<Value>,
-    ) {
+    pub fn replace_runtime(&mut self, task: JoinHandle<Result<(), VmError>>, start_ip: usize) {
         if let Some(task) = &self.task {
             task.abort();
         }
         self.task = Some(task);
         self.start_ip = start_ip;
         self.current_ip = start_ip;
-        self.mailbox = mailbox;
-        self.mailbox_sender = mailbox_sender;
     }
 
     pub async fn run(&mut self) -> Result<(), VmError> {
@@ -161,18 +147,6 @@ impl ProcessHandle {
             .map_err(|err| VmError::Message(err.to_string()))?
             .pop()
             .ok_or(VmError::StackUnderflow)
-    }
-
-    pub fn mailbox_mut(&mut self) -> &mut Receiver<Value> {
-        &mut self.mailbox
-    }
-
-    pub fn is_mailbox_closed(&self) -> bool {
-        self.mailbox.is_closed()
-    }
-
-    pub fn mailbox_sender(&self) -> Sender<Value> {
-        self.mailbox_sender.clone()
     }
 
     pub fn heap_references(&self) -> Vec<usize> {
@@ -271,7 +245,9 @@ impl Heap {
             let Some(object) = self.objects[address].as_ref() else {
                 continue;
             };
-            let external_incoming = object.ref_count().saturating_sub(internal_incoming[address]);
+            let external_incoming = object
+                .ref_count()
+                .saturating_sub(internal_incoming[address]);
             if external_incoming > 0 {
                 reachable[address] = true;
                 worklist.push_back(address);

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -117,7 +117,6 @@ fn spawn_child_vm(
         let debug_info = vm.debug_info();
         let links = vm.links();
         let trap_exits = vm.trap_exits();
-        let mailbox = vm.take_mailbox();
         let final_stack = Arc::new(Mutex::new(Vec::new()));
         let task = run_process(vm, final_stack.clone());
         ProcessHandle::new(
@@ -129,8 +128,6 @@ fn spawn_child_vm(
             links,
             trap_exits,
             task,
-            mailbox,
-            tx.clone(),
             final_stack,
         )
     };
@@ -151,15 +148,9 @@ fn restart_actor(heap: &mut Heap, child: ChildSpec) -> Result<(), VmError> {
             for link in process.links() {
                 vm.link(link);
             }
-            let replacement_mailbox = vm.take_mailbox();
             *sender = replacement_tx.clone();
             let final_stack = Arc::new(Mutex::new(Vec::new()));
-            process.replace_runtime(
-                run_process(vm, final_stack.clone()),
-                child.start_ip,
-                replacement_mailbox,
-                replacement_tx,
-            );
+            process.replace_runtime(run_process(vm, final_stack.clone()), child.start_ip);
             log::info!(
                 "Restarted actor {} at ip {}",
                 child.reference,
@@ -472,7 +463,10 @@ impl Bytecode {
     }
 
     pub fn opcodes(&self) -> Vec<OpCode> {
-        self.opcodes.iter().map(|opcode| opcode.as_ref().clone()).collect()
+        self.opcodes
+            .iter()
+            .map(|opcode| opcode.as_ref().clone())
+            .collect()
     }
 }
 

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -137,11 +137,6 @@ impl VM {
         self.restart_ip = ip;
     }
 
-    pub fn take_mailbox(&mut self) -> Receiver<Value> {
-        let (_tx, replacement_mailbox) = mpsc::channel(1);
-        std::mem::replace(self.execution.mailbox_mut(), replacement_mailbox)
-    }
-
     pub async fn run(&mut self) -> Result<(), VmError> {
         if self.execution.bytecode.is_empty() {
             log::warn!("Attempted to run VM with empty bytecode");


### PR DESCRIPTION
### Motivation
- Prevent actor mailbox receiver from being stranded when spawning child VMs or restarting actors by ensuring the running `VM` retains ownership of its `Receiver` and only the `Sender` is stored in the heap entry.

### Description
- Removed calls to `VM::take_mailbox()` from `spawn_child_vm` and `restart_actor` in `src/vm/opcodes.rs` so the spawned VM keeps its original `Receiver` and only the returned `Sender` is propagated.
- Simplified `ProcessHandle` in `src/vm/heap.rs` by removing the stored mailbox `Receiver`/`Sender` fields and related accessor methods, and updated `ProcessHandle::new` and `replace_runtime` to the new signatures that no longer accept mailbox plumbing.
- Deleted `VM::take_mailbox` from `src/vm/vm.rs` because it is no longer used by the opcode paths.
- Updated call sites to use `process.replace_runtime(run_process(vm, ...), child.start_ip)` and to replace the heap actor `sender` with `replacement_tx.clone()` on restarts.

### Testing
- Ran `cargo fmt` successfully to apply formatting.
- Ran `cargo test -q` which failed due to compile errors reported by `rustc` (errors include missing `SupervisorStrategy`/`ChildSpec` imports and a duplicate `heap_references` definition), so no passing test results are available for this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f203430a883289814d31b394c422e)