### PR TITLE
Harden VM process ID allocation to avoid panic on exhaustion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,6 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub async fn run(source: &str) -> Result<(), VmError> {
     let program = Compiler::compile_with_debug(source)?;
 
-    let (mut vm, _tx) = VM::new_with_debug(program.bytecode, Some(program.debug_info), None);
+    let (mut vm, _tx) = VM::new_with_debug(program.bytecode, Some(program.debug_info), None)?;
     vm.run().await
 }

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -43,6 +43,8 @@ pub enum VmError {
     MailboxEmpty,
     #[error("Mailbox disconnected")]
     MailboxDisconnected,
+    #[error("Process ID space exhausted and no recycled IDs are available")]
+    ProcessIdExhausted,
     #[error("Channel send error: {error}")]
     ChannelSend { error: String, value: Value },
     #[error("Compilation error: {0}")]

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -94,8 +94,8 @@ fn spawn_child_vm(
     parent: Option<&ProcessContext>,
     trap_exits: bool,
     links: Vec<tokio::sync::mpsc::Sender<Value>>,
-) -> (ProcessHandle, tokio::sync::mpsc::Sender<Value>) {
-    let (mut vm, tx) = VM::new_with_debug(bytecode, debug_info, None);
+) -> Result<(ProcessHandle, tokio::sync::mpsc::Sender<Value>), VmError> {
+    let (mut vm, tx) = VM::new_with_debug(bytecode, debug_info, None)?;
     vm.set_ip(start_ip);
     vm.set_restart_ip(start_ip);
     vm.set_trap_exits(trap_exits);
@@ -134,14 +134,20 @@ fn spawn_child_vm(
             final_stack,
         )
     };
-    (handle, tx)
+    Ok((handle, tx))
 }
 
 fn restart_actor(heap: &mut Heap, child: ChildSpec) -> Result<(), VmError> {
     match heap.get_mut(child.reference) {
         Some(HeapObject::Actor(process, sender, _)) => {
             let (mut vm, replacement_tx) =
-                VM::new_with_debug(process.bytecode(), process.debug_info(), None);
+                match VM::new_with_debug(process.bytecode(), process.debug_info(), None) {
+                    Ok(vm) => vm,
+                    Err(error) => {
+                        log::error!("Failed to restart actor VM: {}", error);
+                        return Err(error);
+                    }
+                };
             vm.set_ip(child.start_ip);
             vm.set_restart_ip(child.start_ip);
             vm.set_trap_exits(process.trap_exits());
@@ -472,7 +478,10 @@ impl Bytecode {
     }
 
     pub fn opcodes(&self) -> Vec<OpCode> {
-        self.opcodes.iter().map(|opcode| opcode.as_ref().clone()).collect()
+        self.opcodes
+            .iter()
+            .map(|opcode| opcode.as_ref().clone())
+            .collect()
     }
 }
 
@@ -761,7 +770,7 @@ impl OpCode {
                     process.as_ref(),
                     false,
                     Vec::new(),
-                );
+                )?;
                 let address = heap.allocate(HeapObject::Actor(handle, tx, 0));
                 push_value(execution, heap, Value::Reference(address))
             }
@@ -817,7 +826,7 @@ impl OpCode {
                     process.as_ref(),
                     true,
                     Vec::new(),
-                );
+                )?;
                 let address = heap.allocate(HeapObject::Supervisor(handle, tx, 0));
                 push_value(execution, heap, Value::Reference(address))
             }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -14,23 +14,28 @@ use std::sync::{LazyLock, Mutex};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 static NEXT_PROCESS_ID: AtomicUsize = AtomicUsize::new(1);
+/// Recycled process IDs shared across the entire OS process.
+///
+/// This currently assumes a single embedding context per OS process.
+/// Runtime-scoped process ID allocation is planned to avoid collisions
+/// when multiple embedded runtimes coexist in one host process.
 static RECYCLED_PROCESS_IDS: LazyLock<Mutex<Vec<usize>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 const REDUCTION_QUOTA: usize = 2_000;
 
-fn allocate_process_id() -> usize {
+fn allocate_process_id() -> Result<usize, VmError> {
     if let Some(process_id) = RECYCLED_PROCESS_IDS
         .lock()
         .expect("recycled process id list lock poisoned")
         .pop()
     {
-        return process_id;
+        return Ok(process_id);
     }
 
     NEXT_PROCESS_ID
         .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             current.checked_add(1)
         })
-        .expect("process id space exhausted and no recycled ids available")
+        .map_err(|_| VmError::ProcessIdExhausted)
 }
 
 #[derive(Debug)]
@@ -50,13 +55,14 @@ pub struct VM {
 impl VM {
     pub fn new(bytecode: Vec<OpCode>, supervisor: Option<Sender<usize>>) -> (Self, Sender<Value>) {
         Self::new_with_debug(bytecode, None, supervisor)
+            .expect("failed to allocate process id for VM")
     }
 
     pub fn new_with_debug(
         bytecode: impl Into<Bytecode>,
         debug_info: Option<DebugInfo>,
         supervisor: Option<Sender<usize>>,
-    ) -> (Self, Sender<Value>) {
+    ) -> Result<(Self, Sender<Value>), VmError> {
         let (tx, rx) = mpsc::channel(100);
         let bytecode: Bytecode = bytecode.into();
         log::info!("Initializing VM with {} opcodes", bytecode.len());
@@ -65,12 +71,12 @@ impl VM {
         let mut heap = Heap::new();
         stdlib::install(&mut heap, &mut execution);
 
-        (
+        Ok((
             VM {
                 execution,
                 heap,
                 self_sender: tx.clone(),
-                process_id: allocate_process_id(),
+                process_id: allocate_process_id()?,
                 parent: None,
                 restart_ip: 0,
                 links: Vec::new(),
@@ -79,7 +85,7 @@ impl VM {
                 _supervisor: supervisor,
             },
             tx,
-        )
+        ))
     }
 
     pub fn pop_stack(&mut self) -> Result<Value, VmError> {


### PR DESCRIPTION
### Motivation
- Prevent a panic/DoS where a spawn-happy program exhausts the process ID space by turning PID allocation into a fallible operation that returns a meaningful `VmError` instead of calling `expect` and aborting. 
- Make the process-global recycled-PID behavior explicit to avoid future surprises when multiple runtimes are embedded in the same OS process.

### Description
- Add `VmError::ProcessIdExhausted` to `src/vm/error.rs` to represent PID allocation exhaustion. 
- Change `allocate_process_id` in `src/vm/vm.rs` to return `Result<usize, VmError>` and return `ProcessIdExhausted` on overflow instead of `expect`. 
- Make `VM::new_with_debug` return `Result<(Self, Sender<Value>), VmError>` and propagate PID allocation failures with `?`, while keeping `VM::new` infallible for compatibility by calling `expect` on `new_with_debug`. 
- Update actor construction code paths: change `spawn_child_vm` to return `Result<(ProcessHandle, Sender<Value>), VmError>` and update `OpCode::SpawnActor`/`OpCode::SpawnSupervisor` to propagate construction errors (use `?`), and make `restart_actor` log-and-return constructor failures rather than silently panic. 
- Add a doc comment to `RECYCLED_PROCESS_IDS` noting it is process-wide and that runtime-scoped allocation is planned.

### Testing
- Ran `cargo fmt`, which succeeded. 
- Ran `cargo test -q`, which failed due to pre-existing repository compile issues (supervisor/heap/test mismatches and unrelated type errors) not introduced by this change; the new fallible allocation paths were exercised by compiling the modified modules but overall test suite did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f20553eb8832888a73adddf93c91d)