### PR TITLE
docs: clarify ProcessHandle option 3 contract

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -24,6 +24,29 @@ pub struct NativeFunction {
     pub function: fn(Vec<Value>) -> Result<Value, VmError>,
 }
 
+/// A handle to a process spawned onto the Tokio runtime.
+///
+/// ### Option 3 tradeoff (current contract)
+///
+/// **Buys:** lightweight process tracking that can await task completion and
+/// inspect captured post-mortem state.
+///
+/// **Costs:** no live mailbox ownership through the handle while the process is
+/// running.
+///
+/// A `ProcessHandle` represents a process that has been spawned onto the Tokio
+/// runtime. While the process is running, its mailbox is owned by the VM inside
+/// the spawned task; the handle does not provide a way to peek at or close the
+/// mailbox in-flight. To send messages, use the `Sender<Value>` stored
+/// alongside the handle in `HeapObject::Actor`.
+///
+/// To inspect a process post-mortem, await [`ProcessHandle::run`] (which awaits
+/// the underlying `JoinHandle`) and then read [`ProcessHandle::pop_stack`] or
+/// [`ProcessHandle::heap_references`] from the captured `final_stack`.
+///
+/// This makes the limitation explicit and gives Phase 1 a clear target:
+/// introduce a proper `Process` type that is not moved into a Tokio task and
+/// can therefore provide live mailbox access.
 #[derive(Debug)]
 pub struct ProcessHandle {
     process_id: usize,


### PR DESCRIPTION
### Motivation
- Make the Option 3 tradeoff explicit by documenting what is gained and lost (lightweight, post‑mortem inspection vs no live mailbox access) and call out the Phase 1 target to introduce a `Process` type that can provide live mailbox access.

### Description
- Add a detailed struct doc comment above `ProcessHandle` in `src/vm/heap.rs` that explains the Option 3 buys/costs, states that the mailbox is owned by the spawned VM task while running, directs senders to use the `Sender<Value>` stored with `HeapObject::Actor`, documents the post‑mortem inspection flow (await `ProcessHandle::run` then read `pop_stack`/`heap_references` from the captured `final_stack`), and notes the Phase 1 migration target.

### Testing
- Ran `cargo test -q`, which failed due to pre-existing compile errors unrelated to this docs-only change (the new comment does not affect compilation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f20668f2c8328990e7ba97230fd93)