### PR TITLE
Rewrite mailbox-dependent tests to avoid actor mailbox access

### DIFF
--- a/tests/reference_counts.rs
+++ b/tests/reference_counts.rs
@@ -43,9 +43,9 @@ async fn actor_reference_lifecycle_on_stack() {
 
 #[tokio::test]
 async fn send_and_receive_message_updates_reference_counts() {
-    let (tx, mailbox) = channel(1);
-    let mut execution = ExecutionContext::with_mailbox(vec![OpCode::Return], mailbox);
+    let (_tx, mailbox) = channel(1);
     let mut heap = Heap::new();
+    let mut execution = ExecutionContext::with_mailbox(vec![OpCode::Return], mailbox);
 
     // Spawn target actor (A) and message actor (B)
     OpCode::SpawnActor(0)
@@ -73,40 +73,40 @@ async fn send_and_receive_message_updates_reference_counts() {
     assert_eq!(actor_ref_count(&heap, actor_a), 1, "actor on stack");
     assert_eq!(actor_ref_count(&heap, actor_b), 1, "message queued");
 
-    // Simulate the message arriving back to this VM's mailbox.
-    let message = {
-        let actor_entry = heap.get_mut(actor_a).expect("Expected actor VM for target");
-        match actor_entry {
-            HeapObject::Actor(vm, _, _) => vm.mailbox_mut().recv().await,
-            _ => panic!("Expected actor VM for target"),
-        }
-    }
-    .expect("Actor mailbox was empty");
-
-    if let Value::Reference(addr) = message {
-        if let Some(object) = heap.get_mut(addr) {
-            object.decrement_ref();
-            object.increment_ref();
-        } else {
-            panic!("Message reference not found in heap");
-        }
-    }
-
-    tx.send(message).await.unwrap();
-
-    OpCode::ReceiveMessage
-        .execute(&mut execution, &mut heap)
-        .unwrap();
-
-    assert_eq!(actor_ref_count(&heap, actor_b), 1, "message now on stack");
-
     // Drop both stack references and collect.
     OpCode::Pop.execute(&mut execution, &mut heap).unwrap();
     OpCode::Pop.execute(&mut execution, &mut heap).unwrap();
+    assert_eq!(actor_ref_count(&heap, actor_a), 0);
     assert_eq!(actor_ref_count(&heap, actor_b), 0);
 
     heap.collect_garbage();
+    assert!(heap.get(actor_a).is_none());
     assert!(heap.get(actor_b).is_none());
+}
+
+#[tokio::test]
+async fn receive_message_updates_reference_counts() {
+    let (tx, mailbox) = channel(1);
+    let mut execution = ExecutionContext::with_mailbox(vec![OpCode::Return], mailbox);
+    let mut heap = Heap::new();
+
+    let message_addr = heap.allocate(HeapObject::Array(vec![], 1));
+    tx.send(Value::Reference(message_addr))
+        .await
+        .expect("sending message into mailbox should succeed");
+
+    OpCode::ReceiveMessage
+        .execute(&mut execution, &mut heap)
+        .expect("ReceiveMessage should push message onto stack");
+
+    assert_eq!(execution.stack, vec![Value::Reference(message_addr)]);
+    match heap
+        .get(message_addr)
+        .expect("message object should still be allocated")
+    {
+        HeapObject::Array(_, rc) => assert_eq!(*rc, 2, "message should be retained on stack"),
+        other => panic!("expected array at message_addr, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -1,6 +1,8 @@
 use raft::vm::execution::ExecutionContext;
-use raft::vm::heap::{Heap, HeapObject};
+use raft::vm::heap::{Heap, HeapObject, ProcessHandle};
 use raft::vm::{error::VmError, opcodes::OpCode, value::Value, vm::VM};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc::channel;
 
 #[tokio::test]
 async fn division_by_zero_returns_error() {
@@ -183,14 +185,27 @@ async fn spawn_supervisor_at_bytecode_len_returns_error() {
 async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
     let mut execution = ExecutionContext::new(vec![OpCode::Return]);
     let mut heap = Heap::new();
-    // Stack layout expected by SendMessage is [message, actor_ref].
-    OpCode::SpawnActor(0)
-        .execute(&mut execution, &mut heap)
-        .expect("spawn actor should succeed");
-    let actor_addr = match execution.stack.last().copied() {
-        Some(Value::Reference(addr)) => addr,
-        other => panic!("expected actor reference, got {other:?}"),
-    };
+
+    let (dead_sender, dead_receiver) = channel::<Value>(1);
+    drop(dead_receiver);
+    let (_mailbox_sender, mailbox) = channel::<Value>(1);
+    let final_stack = Arc::new(Mutex::new(Vec::new()));
+    let task = tokio::spawn(async { Ok(()) });
+    let handle = ProcessHandle::new(
+        1,
+        None,
+        0,
+        Vec::new(),
+        None,
+        Vec::new(),
+        false,
+        task,
+        mailbox,
+        dead_sender.clone(),
+        final_stack,
+    );
+    let actor_addr = heap.allocate(HeapObject::Actor(handle, dead_sender, 1));
+    execution.stack.push(Value::Reference(actor_addr));
 
     let message_addr = heap.allocate(HeapObject::Array(vec![], 0));
     OpCode::PushConst(Value::Reference(message_addr))
@@ -200,18 +215,9 @@ async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
         .execute(&mut execution, &mut heap)
         .expect("swap should succeed");
 
-    // Close actor mailbox to force ChannelSend error.
-    let actor_entry = heap
-        .get_mut(actor_addr)
-        .expect("spawned actor should be in heap");
-    match actor_entry {
-        HeapObject::Actor(actor_vm, _, _) => actor_vm.mailbox_mut().close(),
-        other => panic!("expected actor in heap, got {other:?}"),
-    }
-
     let err = OpCode::SendMessage
         .execute(&mut execution, &mut heap)
-        .expect_err("send should fail when mailbox is closed");
+        .expect_err("send should fail when mailbox receiver is dropped");
 
     match err {
         VmError::ChannelSend { value, .. } => {


### PR DESCRIPTION
### Motivation
- Existing tests peeked directly into a running actor's mailbox (`HeapObject::Actor(... ) => vm.mailbox_mut().recv().await`), which is no longer allowed.  
- The goal is to keep the original test semantics (verify `SendMessage`/`ReceiveMessage` refcount behavior and error handling) without reaching into actor internals.  
- Make message send failure deterministic without manipulating a spawned actor's mailbox so the test remains robust and isolated.

### Description
- Updated `tests/reference_counts.rs` so `send_and_receive_message_updates_reference_counts` no longer inspects actor mailboxes and only verifies `SendMessage` refcount effects and that both actors are reclaimed after dropping stack refs and running GC.  
- Added `receive_message_updates_reference_counts` to `tests/reference_counts.rs` which constructs a mailbox pair, allocates a message `HeapObject`, sends it via `tx`, executes `OpCode::ReceiveMessage`, and asserts the stack and refcount transitions.  
- Modified `tests/vm_errors.rs::send_message_failure_preserves_actor_on_stack_and_ref_counts` to allocate a `HeapObject::Actor` backed by a `ProcessHandle` with a closed sender (receiver dropped) so `OpCode::SendMessage` deterministically returns `VmError::ChannelSend`, preserving the original assertions about stack and refcount behavior, and added required imports (`ProcessHandle`, `Arc`, `Mutex`, `channel`).

### Testing
- Attempted to run the updated test targets with `cargo test` for the modified tests, but the build failed during compilation due to unrelated pre-existing errors in core code (`src/vm/vm.rs` and `src/vm/heap.rs`, e.g. missing `SupervisorStrategy`/`ChildSpec` imports and a duplicate `heap_references` definition), so the new tests were not executed.  
- No test failures were observed from the test edits themselves because compilation prevented running the test binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f204f89e08328a3da9d9f04e3d5d3)