### PR TITLE
Fix ProcessHandle::new call sites and send-failure tests after signature change

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -458,7 +458,6 @@ mod tests {
         let (actor_sender, _actor_mailbox) = tokio::sync::mpsc::channel(1);
         let final_stack = Arc::new(Mutex::new(vec![Value::Reference(array_address)]));
         let task = runtime.spawn(async { Ok(()) });
-        let (mailbox_sender, mailbox) = tokio::sync::mpsc::channel(1);
         let actor = ProcessHandle::new(
             1,
             None,
@@ -468,8 +467,6 @@ mod tests {
             Vec::new(),
             false,
             task,
-            mailbox,
-            mailbox_sender,
             final_stack,
         );
         let actor_address = heap.allocate(HeapObject::Actor(actor, actor_sender, 1));

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -499,13 +499,15 @@ mod tests {
         vm.execution.step(&mut vm.heap).unwrap();
         vm.execution.step(&mut vm.heap).unwrap();
 
-        // Close actor mailbox to force send failure
+        // Swap actor sender with a closed channel to force send failure
         let actor_addr = match vm.execution.stack.last() {
             Some(Value::Reference(addr)) => *addr,
             other => panic!("Expected actor reference, got {:?}", other),
         };
-        if let Some(HeapObject::Actor(actor_vm, _, _)) = vm.heap.get_mut(actor_addr) {
-            actor_vm.mailbox_mut().close();
+        if let Some(HeapObject::Actor(_, actor_sender, _)) = vm.heap.get_mut(actor_addr) {
+            let (closed_sender, closed_receiver) = mpsc::channel(1);
+            drop(closed_receiver);
+            *actor_sender = closed_sender;
         } else {
             panic!("Expected HeapObject::Actor");
         }
@@ -536,7 +538,6 @@ mod tests {
         use crate::vm::heap::ProcessHandle;
         use crate::vm::HeapObject;
         use std::sync::{Arc, Mutex};
-        use tokio::sync::Mutex;
 
         let (mut vm, _tx) = VM::new(vec![OpCode::Return], None);
         let (sender, receiver) = mpsc::channel(1);
@@ -544,7 +545,6 @@ mod tests {
 
         let (actor_sender, _actor_mailbox) = mpsc::channel(1);
         let task = tokio::spawn(async { Ok(()) });
-        let (mailbox_sender, mailbox) = mpsc::channel(1);
         let final_stack = Arc::new(Mutex::new(Vec::new()));
         let actor_vm = ProcessHandle::new(
             1,
@@ -555,8 +555,6 @@ mod tests {
             Vec::new(),
             false,
             task,
-            mailbox,
-            mailbox_sender,
             final_stack,
         );
         let actor_addr = vm

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -188,7 +188,6 @@ async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
 
     let (dead_sender, dead_receiver) = channel::<Value>(1);
     drop(dead_receiver);
-    let (_mailbox_sender, mailbox) = channel::<Value>(1);
     let final_stack = Arc::new(Mutex::new(Vec::new()));
     let task = tokio::spawn(async { Ok(()) });
     let handle = ProcessHandle::new(
@@ -200,8 +199,6 @@ async fn send_message_failure_preserves_actor_on_stack_and_ref_counts() {
         Vec::new(),
         false,
         task,
-        mailbox,
-        dead_sender.clone(),
         final_stack,
     );
     let actor_addr = heap.allocate(HeapObject::Actor(handle, dead_sender, 1));


### PR DESCRIPTION
### Motivation
- Tests and some unit test helpers still passed `mailbox`/`mailbox_sender` to `ProcessHandle::new` even though the constructor was reduced to 9 arguments, causing compilation failures.
- A VM unit test attempted to call a removed `mailbox_mut()` helper on `ProcessHandle`, so the test needed a new way to induce a send failure.
- Duplicate imports of `Mutex` (both `std::sync::Mutex` and `tokio::sync::Mutex`) created an import conflict in a test module.

### Description
- Updated stale `ProcessHandle::new` call sites to match the current 9-argument signature by removing the obsolete `mailbox`/`mailbox_sender` parameters in `tests/vm_errors.rs`, `src/vm/heap.rs`, and `src/vm/vm.rs`.
- Reworked the send-failure unit test in `src/vm/vm.rs` to force a send failure by replacing the actor's `Sender` in the heap with a closed channel rather than calling the removed `mailbox_mut()` method on `ProcessHandle`.
- Removed the unnecessary `tokio::sync::Mutex` import where it conflicted with `std::sync::Mutex` in the VM tests.

### Testing
- Ran `cargo test --no-run` which completed successfully and produced compiled test binaries without compilation errors.
- Verified that the updated test modules referencing `ProcessHandle::new` now compile under the test profile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f5608c16883288e088f3c659300f3)