### PR TITLE
Use global atomic process ID allocator

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -9,23 +9,18 @@ use crate::vm::opcodes::{Bytecode, OpCode};
 use crate::vm::supervision::{ExitReason, ExitSignal};
 use crate::vm::value::{MessageValue, Value};
 
-use std::cell::Cell;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
-thread_local! {
-    static NEXT_PROCESS_ID: Cell<usize> = const { Cell::new(1) };
-}
+static NEXT_PROCESS_ID: AtomicUsize = AtomicUsize::new(1);
 const REDUCTION_QUOTA: usize = 2_000;
 
 fn allocate_process_id() -> Result<usize, VmError> {
-    NEXT_PROCESS_ID.with(|next| {
-        let process_id = next.get();
-        let next_id = process_id
-            .checked_add(1)
-            .ok_or(VmError::ProcessIdExhausted)?;
-        next.set(next_id);
-        Ok(process_id)
-    })
+    NEXT_PROCESS_ID
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |process_id| {
+            process_id.checked_add(1)
+        })
+        .map_err(|_| VmError::ProcessIdExhausted)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
### Motivation
- The thread-local `NEXT_PROCESS_ID` started at `1` per Tokio worker thread, causing duplicate PIDs under the default multi-threaded runtime and breaking semantics that rely on PID uniqueness.

### Description
- Replace the thread-local `Cell<usize>` with a single global `static NEXT_PROCESS_ID: AtomicUsize`.
- Update `allocate_process_id` to use `fetch_update` with `Ordering::Relaxed` and map overflow to `VmError::ProcessIdExhausted` to preserve existing exhaustion behavior.
- This change ensures process IDs are unique across Tokio worker threads when spawning actors.

### Testing
- Ran `cargo test spawn_opcodes_allocate_one_process_id_each --test supervision`, which compiled and passed (1 test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6458b1388328b76b708f9ee8d354)