### PR TITLE
Fix transient child refcount drops in StoreVar

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -599,14 +599,10 @@ impl OpCode {
                 Ok(())
             }
             OpCode::StoreVar(index) => {
-                let value = pop_value(execution, heap)?;
+                let value = pop_raw_value(execution)?;
 
-                if let Some(Value::Reference(address)) = execution.locals.insert(*index, value) {
-                    heap.release_reference(address)?;
-                }
-
-                if let Value::Reference(address) = value {
-                    increment_reference(heap, address)?;
+                if let Some(previous) = execution.locals.insert(*index, value) {
+                    release_value(heap, previous)?;
                 }
 
                 Ok(())
@@ -1012,5 +1008,36 @@ mod heap_opcode_tests {
             .execute(&mut execution, &mut heap)
             .unwrap();
         assert_eq!(execution.stack.pop(), Some(Value::Integer(5)));
+    }
+
+    #[tokio::test]
+    async fn store_var_preserves_child_reference_counts() {
+        let mut execution = ExecutionContext::new(vec![OpCode::Return]);
+        let mut heap = Heap::new();
+
+        OpCode::MakeString("child".to_string())
+            .execute(&mut execution, &mut heap)
+            .unwrap();
+        let child_address = match execution.stack.last().copied() {
+            Some(Value::Reference(address)) => address,
+            other => panic!("expected child string reference on stack, got {other:?}"),
+        };
+
+        OpCode::MakeArray(1).execute(&mut execution, &mut heap).unwrap();
+        let parent_address = match execution.stack.last().copied() {
+            Some(Value::Reference(address)) => address,
+            other => panic!("expected parent array reference on stack, got {other:?}"),
+        };
+
+        OpCode::StoreVar(0).execute(&mut execution, &mut heap).unwrap();
+
+        match heap.get(parent_address) {
+            Some(HeapObject::Array(_, rc)) => assert_eq!(*rc, 1, "stored parent should be retained"),
+            other => panic!("expected stored parent array in heap, got {other:?}"),
+        }
+        match heap.get(child_address) {
+            Some(HeapObject::String(_, rc)) => assert_eq!(*rc, 1, "child should remain retained by parent"),
+            other => panic!("expected child string in heap, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- `StoreVar` previously used `pop_value` which released the popped reference (cascading to children) then re-incremented the parent, leaving children transiently at `rc = 0` and exposing a race if GC runs during the opcode.

### Description
- Change `OpCode::StoreVar` to take the stack value with `pop_raw_value` and treat it as a direct ownership transfer into `execution.locals` to avoid decrement/re-increment cycles.
- When replacing an existing local binding, call `release_value(heap, previous)` to dispose the old value explicitly.
- Add a regression test `store_var_preserves_child_reference_counts` that constructs a parent array containing a child string, stores the parent to a local, and asserts both parent and child refcounts remain `1`.

### Testing
- Ran `cargo test store_var_preserves_child_reference_counts -- --nocapture`, which passed.
- Ran the repository test suite (`cargo test`) locally; tests completed with warnings only and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6473f820832890ecd9f12b026a91)