### PR TITLE
Align Actor::send with SendMessage reference conversion

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -44,14 +44,7 @@ impl Actor {
 
     /// Send a message to the actor's mailbox.
     pub async fn send(&self, msg: Value) -> Result<(), VmError> {
-        let message = match msg {
-            Value::Integer(v) => MessageValue::Integer(v),
-            Value::Float(v) => MessageValue::Float(v),
-            Value::Boolean(v) => MessageValue::Boolean(v),
-            Value::ExitSignal(v) => MessageValue::ExitSignal(v),
-            Value::Null => MessageValue::Null,
-            Value::Reference(_) => return Err(VmError::TypeMismatch("Actor::send reference unsupported")),
-        };
+        let message = self.vm.value_to_message(msg)?;
         self.sender.send(message).await.map_err(|e| {
             let error = e.to_string();
             let value = match e.0 {
@@ -72,13 +65,17 @@ impl Actor {
 
     /// Receive the next message if available.
     pub async fn handle_next_message(&mut self) -> Option<Value> {
-        self.vm.mailbox_mut().recv().await.and_then(|message| match message {
-            MessageValue::Integer(v) => Some(Value::Integer(v)),
-            MessageValue::Float(v) => Some(Value::Float(v)),
-            MessageValue::Boolean(v) => Some(Value::Boolean(v)),
-            MessageValue::ExitSignal(v) => Some(Value::ExitSignal(v)),
-            MessageValue::Null => Some(Value::Null),
-            _ => None,
-        })
+        self.vm
+            .mailbox_mut()
+            .recv()
+            .await
+            .and_then(|message| match message {
+                MessageValue::Integer(v) => Some(Value::Integer(v)),
+                MessageValue::Float(v) => Some(Value::Float(v)),
+                MessageValue::Boolean(v) => Some(Value::Boolean(v)),
+                MessageValue::ExitSignal(v) => Some(Value::ExitSignal(v)),
+                MessageValue::Null => Some(Value::Null),
+                _ => None,
+            })
     }
 }

--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -394,9 +394,11 @@ impl Heap {
                     .map(|(k, v)| Ok((k.clone(), self.value_to_message(*v)?)))
                     .collect::<Result<HashMap<_, _>, VmError>>()?,
             )),
-            HeapObject::NativeFunction(_, _) | HeapObject::Actor(_, _, _) | HeapObject::Supervisor(_, _, _) => {
-                Err(VmError::TypeMismatch("SendMessage unsupported reference type"))
-            }
+            HeapObject::NativeFunction(_, _)
+            | HeapObject::Actor(_, _, _)
+            | HeapObject::Supervisor(_, _, _) => Err(VmError::TypeMismatch(
+                "SendMessage unsupported reference type",
+            )),
         }
     }
 

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -43,7 +43,10 @@ pub struct VM {
 }
 
 impl VM {
-    pub fn new(bytecode: Vec<OpCode>, supervisor: Option<Sender<usize>>) -> (Self, Sender<MessageValue>) {
+    pub fn new(
+        bytecode: Vec<OpCode>,
+        supervisor: Option<Sender<usize>>,
+    ) -> (Self, Sender<MessageValue>) {
         Self::new_with_debug(bytecode, None, supervisor)
             .expect("failed to allocate process id for VM")
     }
@@ -203,7 +206,10 @@ impl VM {
                     let error = err.to_string();
                     let _value = err.0;
                     self.push_runtime_value(Value::Reference(actor_address))?;
-                    Err(VmError::ChannelSend { error, value: Value::Null })
+                    Err(VmError::ChannelSend {
+                        error,
+                        value: Value::Null,
+                    })
                 }
             },
         }
@@ -280,6 +286,10 @@ impl VM {
 
     pub fn sender(&self) -> Sender<MessageValue> {
         self.self_sender.clone()
+    }
+
+    pub fn value_to_message(&self, value: Value) -> Result<MessageValue, VmError> {
+        self.heap.value_to_message(value)
     }
 
     pub fn link(&mut self, sender: Sender<MessageValue>) {

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -1,6 +1,11 @@
 use raft::vm::execution::ExecutionContext;
 use raft::vm::heap::{Heap, HeapObject, ProcessHandle};
-use raft::vm::{error::VmError, opcodes::OpCode, value::{MessageValue, Value}, vm::VM};
+use raft::vm::{
+    error::VmError,
+    opcodes::OpCode,
+    value::{MessageValue, Value},
+    vm::VM,
+};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::channel;
 


### PR DESCRIPTION
### Motivation

- `Actor::send` previously rejected all `Value::Reference` values, which made the public Actor API weaker than the VM `SendMessage` opcode and prevented Rust callers from sending message-compatible heap values like arrays, strings, and modules.
- The change is intended to make the runtime API consistent with the VM opcode behavior by reusing the same reference-to-message conversion logic.

### Description

- Route `Actor::send` through the VM conversion by calling `VM::value_to_message` so the actor API deep-copies supported heap objects into `MessageValue` instead of rejecting references (change in `src/runtime.rs`).
- Add `pub fn value_to_message(&self, value: Value) -> Result<MessageValue, VmError>` to `VM` that delegates to `heap.value_to_message` to expose the heap conversion to runtime code (change in `src/vm/vm.rs`).
- Minor formatting adjustments in `src/vm/heap.rs` and `tests/vm_errors.rs` with no behavioral change to the heap conversion logic.

### Testing

- Ran `cargo fmt` successfully to apply formatting updates.
- Ran `cargo test -q` and all tests passed (`ok`, with the full test suite succeeding).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f648b652c8328a3b58af3e10c7e0c)