### PR TITLE
docs: remove internal 'Option 3 tradeoff' notes from ProcessHandle docs

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -26,14 +26,6 @@ pub struct NativeFunction {
 
 /// A handle to a process spawned onto the Tokio runtime.
 ///
-/// ### Option 3 tradeoff (current contract)
-///
-/// **Buys:** lightweight process tracking that can await task completion and
-/// inspect captured post-mortem state.
-///
-/// **Costs:** no live mailbox ownership through the handle while the process is
-/// running.
-///
 /// A `ProcessHandle` represents a process that has been spawned onto the Tokio
 /// runtime. While the process is running, its mailbox is owned by the VM inside
 /// the spawned task; the handle does not provide a way to peek at or close the


### PR DESCRIPTION
### Motivation
- Remove internal design notes from the public doc comment for `ProcessHandle` so the documentation remains user-facing and does not expose implementation tradeoffs.

### Description
- Delete the `Option 3 tradeoff` subsection from the `ProcessHandle` doc comment in `src/vm/heap.rs` while keeping the remaining documentation about mailbox ownership and post-mortem inspection.

### Testing
- Ran `cargo test --quiet` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f64ad5604832893a621a7c2232668)