### PR TITLE
Fix SendMessage reference leak and stack effect on full channel

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -779,9 +779,8 @@ impl OpCode {
                 push_value(execution, heap, Value::Reference(address))
             }
             OpCode::SendMessage => {
-                // SendMessage has stack-stable behavior for actor references:
-                // the actor reference is present on the stack after the opcode
-                // finishes, regardless of success or failure.
+                // SendMessage consumes the message and leaves the actor reference
+                // on the stack (or restores it on failure/yield).
                 let actor_ref = pop_raw_value(execution)?;
                 let message = pop_value(execution, heap)?;
                 if let Value::Reference(address) = actor_ref {
@@ -789,13 +788,9 @@ impl OpCode {
                         Some(HeapObject::Actor(_, sender, _)) => sender.clone(),
                         _ => return Err(VmError::InvalidReference),
                     };
-                    if let Value::Reference(message_address) = message {
-                        increment_reference(heap, message_address)?;
-                    }
                     let message_for_channel = heap.value_to_message(message)?;
                     match sender.try_send(message_for_channel) {
                         Ok(()) => {
-                            push_existing_value(execution, message);
                             push_existing_value(execution, Value::Reference(address));
                             Ok(())
                         }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -340,7 +340,7 @@ impl VM {
 mod tests {
     use super::*;
     use crate::vm::opcodes::OpCode;
-    use crate::vm::value::{MessageValue, Value};
+    use crate::vm::value::Value;
 
     #[tokio::test]
     async fn test_basic_arithmetic() {

--- a/tests/reference_counts.rs
+++ b/tests/reference_counts.rs
@@ -70,12 +70,11 @@ async fn send_and_receive_message_updates_reference_counts() {
 
     assert_eq!(actor_ref_count(&heap, actor_a), 1, "actor on stack");
     match heap.get(message_ref) {
-        Some(HeapObject::Array(_, rc)) => assert_eq!(*rc, 1, "message queued"),
+        Some(HeapObject::Array(_, rc)) => assert_eq!(*rc, 0, "message consumed"),
         other => panic!("expected message array, got {other:?}"),
     }
 
-    // Drop both stack references and collect.
-    OpCode::Pop.execute(&mut execution, &mut heap).unwrap();
+    // Drop the remaining actor stack reference and collect.
     OpCode::Pop.execute(&mut execution, &mut heap).unwrap();
     assert_eq!(actor_ref_count(&heap, actor_a), 0);
     match heap.get(message_ref) {


### PR DESCRIPTION
### Motivation
- SendMessage previously retained a `Value::Reference` for the message before conversion and yielded on a full channel, leaving an incremented reference with no owner and leaking reference counts.
- The opcode had inconsistent stack effects between immediate success (pushing message and actor) and the blocking yield/resume path (restoring only the actor), which could leave orphaned values on the stack.

### Description
- Make `SendMessage` consistently consume the message and ensure only the actor reference remains on the stack on success or is restored on failure/yield by changing the opcode behavior in `src/vm/opcodes.rs`.
- Remove the pre-send `increment_reference` on the message path to avoid retaining an unowned `Value::Reference` when `try_send` returns `Full`.
- Update reference-count expectations in `tests/reference_counts.rs` to reflect that the message is consumed on send and only the actor remains on the stack.
- Remove an now-unused `MessageValue` import from VM tests in `src/vm/vm.rs`.

### Testing
- Ran `cargo test -q --test reference_counts send_and_receive_message_updates_reference_counts` and the modified `send_and_receive_message_updates_reference_counts` test passed.
- Ran `cargo test -q test_spawn_actor_and_message_delivery` and `test_spawn_actor_and_message_delivery` passed.
- Ran `cargo test -q blocking_send_failure_releases_retained_message_reference` and that test passed, validating blocking-path behavior.
- All automated tests executed for the modified areas passed after the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f646dd3ec832895ce6cc29a78fe17)