### PR TITLE
Make VM Value non-Copy and require explicit clone points

### DIFF
--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -384,14 +384,14 @@ impl Heap {
             HeapObject::Array(values, _) => Ok(MessageValue::Array(
                 values
                     .iter()
-                    .map(|value| self.value_to_message(*value))
+                    .map(|value| self.value_to_message(value.clone()))
                     .collect::<Result<Vec<_>, _>>()?,
             )),
             HeapObject::String(value, _) => Ok(MessageValue::String(value.clone())),
             HeapObject::Module { exports, .. } => Ok(MessageValue::Module(
                 exports
                     .iter()
-                    .map(|(k, v)| Ok((k.clone(), self.value_to_message(*v)?)))
+                    .map(|(k, v)| Ok((k.clone(), self.value_to_message(v.clone())?)))
                     .collect::<Result<HashMap<_, _>, VmError>>()?,
             )),
             HeapObject::NativeFunction(_, _) | HeapObject::Actor(_, _, _) | HeapObject::Supervisor(_, _, _) => {

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -50,7 +50,7 @@ fn decrement_reference(heap: &mut Heap, address: usize) -> Result<(), VmError> {
             HeapObject::Array(elements, rc) if *rc == 1 => elements.clone(),
             HeapObject::Module {
                 exports, ref_count, ..
-            } if *ref_count == 1 => exports.values().copied().collect(),
+            } if *ref_count == 1 => exports.values().cloned().collect(),
             _ => Vec::new(),
         };
         object.decrement_ref();
@@ -207,9 +207,9 @@ fn expect_usize(value: Value, operation: &'static str) -> Result<usize, VmError>
     }
 }
 
-fn retain_value(heap: &mut Heap, value: Value) -> Result<(), VmError> {
+fn retain_value(heap: &mut Heap, value: &Value) -> Result<(), VmError> {
     if let Value::Reference(address) = value {
-        increment_reference(heap, address)?;
+        increment_reference(heap, *address)?;
     }
     Ok(())
 }
@@ -237,7 +237,7 @@ fn make_array(
     elements.reverse();
 
     for value in &elements {
-        retain_value(heap, *value)?;
+        retain_value(heap, &value)?;
     }
 
     let address = heap.allocate(HeapObject::Array(elements, 0));
@@ -252,7 +252,7 @@ fn array_get(execution: &mut ExecutionContext, heap: &mut Heap) -> Result<(), Vm
             Some(HeapObject::Array(elements, _)) => {
                 elements
                     .get(index)
-                    .copied()
+                    .cloned()
                     .ok_or(VmError::IndexOutOfBounds {
                         index,
                         length: elements.len(),
@@ -276,7 +276,7 @@ fn array_set(execution: &mut ExecutionContext, heap: &mut Heap) -> Result<(), Vm
         _ => return Err(VmError::TypeMismatch("ArraySet")),
     };
 
-    retain_value(heap, new_value)?;
+    retain_value(heap, &new_value)?;
     let old_value = match heap.get_mut(address) {
         Some(HeapObject::Array(elements, _)) => {
             if index >= elements.len() {
@@ -341,7 +341,7 @@ fn make_module(
 
     let mut exports = std::collections::HashMap::with_capacity(names.len());
     for (name, value) in names.iter().cloned().zip(values.into_iter()) {
-        retain_value(heap, value)?;
+        retain_value(heap, &value)?;
         exports.insert(name, value);
     }
 
@@ -363,14 +363,14 @@ fn module_get(
         Value::Reference(address) => match heap.get(address) {
             Some(HeapObject::Module { exports, .. }) => exports
                 .get(name)
-                .copied()
+                .cloned()
                 .ok_or_else(|| VmError::Message(format!("Module export not found: {name}")))?,
             _ => return Err(VmError::InvalidReference),
         },
         _ => return Err(VmError::TypeMismatch("ModuleGet")),
     };
     release_value(heap, module_ref)?;
-    push_value(execution, heap, value)
+    push_value(execution, heap, value.clone())
 }
 
 fn module_set(
@@ -385,7 +385,7 @@ fn module_set(
         _ => return Err(VmError::TypeMismatch("ModuleSet")),
     };
 
-    retain_value(heap, new_value)?;
+    retain_value(heap, &new_value)?;
     let old_value = match heap.get_mut(address) {
         Some(HeapObject::Module { exports, .. }) => exports.insert(name.to_string(), new_value),
         _ => {
@@ -577,15 +577,15 @@ impl OpCode {
                 Value::Float(f) => Ok(Value::Float(-f)),
                 _ => Err(VmError::TypeMismatch("Neg")),
             }),
-            OpCode::PushConst(v) => push_value(execution, heap, *v),
+            OpCode::PushConst(v) => push_value(execution, heap, v.clone()),
             OpCode::MakeArray(length) => make_array(execution, heap, *length),
             OpCode::Pop => {
                 pop_value(execution, heap)?;
                 Ok(())
             }
             OpCode::Dup => {
-                if let Some(&value) = execution.stack.last() {
-                    push_value(execution, heap, value)
+                if let Some(value) = execution.stack.last() {
+                    push_value(execution, heap, value.clone())
                 } else {
                     Err(VmError::StackUnderflow)
                 }
@@ -601,7 +601,7 @@ impl OpCode {
             OpCode::StoreVar(index) => {
                 let value = pop_value(execution, heap)?;
 
-                if let Some(Value::Reference(address)) = execution.locals.insert(*index, value) {
+                if let Some(Value::Reference(address)) = execution.locals.insert(*index, value.clone()) {
                     heap.release_reference(address)?;
                 }
 
@@ -613,7 +613,7 @@ impl OpCode {
             }
             OpCode::LoadVar(index) => {
                 if let Some(value) = execution.locals.get(index) {
-                    push_value(execution, heap, *value)
+                    push_value(execution, heap, value.clone())
                 } else {
                     Err(VmError::VariableNotFound(*index))
                 }
@@ -622,9 +622,9 @@ impl OpCode {
                 let value = execution
                     .globals
                     .get(name)
-                    .copied()
+                    .cloned()
                     .ok_or_else(|| VmError::GlobalNotFound(name.clone()))?;
-                push_value(execution, heap, value)
+                push_value(execution, heap, value.clone())
             }
             OpCode::GetExport(export) => {
                 let module_ref = pop_value(execution, heap)?;
@@ -634,7 +634,7 @@ impl OpCode {
 
                 let (module_name, value) = match heap.get(address) {
                     Some(HeapObject::Module { name, exports, .. }) => {
-                        let value = exports.get(export).copied().ok_or_else(|| {
+                        let value = exports.get(export).cloned().ok_or_else(|| {
                             VmError::ExportNotFound {
                                 module: name.clone(),
                                 export: export.clone(),
@@ -646,7 +646,7 @@ impl OpCode {
                 };
 
                 log::info!("Loaded export {} from module {}", export, module_name);
-                push_value(execution, heap, value)
+                push_value(execution, heap, value.clone())
             }
             OpCode::Mod => binary_op(execution, heap, |a, b| match (a, b) {
                 (Value::Integer(x), Value::Integer(y)) => {
@@ -747,7 +747,7 @@ impl OpCode {
                 Ok(message) => {
                     log::info!("Received message: {:?}", message);
                     let value = heap.message_to_value(message)?;
-                    push_value(execution, heap, value)
+                    push_value(execution, heap, value.clone())
                 }
                 Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
                     return Ok(ExecutionState::Yield(BlockingOperation::ReceiveMessage));
@@ -792,7 +792,7 @@ impl OpCode {
                     if let Value::Reference(message_address) = message {
                         increment_reference(heap, message_address)?;
                     }
-                    let message_for_channel = heap.value_to_message(message)?;
+                    let message_for_channel = heap.value_to_message(message.clone())?;
                     match sender.try_send(message_for_channel) {
                         Ok(()) => {
                             push_existing_value(execution, message);
@@ -908,7 +908,7 @@ mod heap_opcode_tests {
             .execute(&mut execution, &mut heap)
             .unwrap();
 
-        let array_addr = match execution.stack.last().copied() {
+        let array_addr = match execution.stack.last().cloned() {
             Some(Value::Reference(address)) => address,
             other => panic!("expected array reference, got {other:?}"),
         };
@@ -954,7 +954,7 @@ mod heap_opcode_tests {
             .execute(&mut execution, &mut heap)
             .unwrap();
 
-        let address = match execution.stack.last().copied() {
+        let address = match execution.stack.last().cloned() {
             Some(Value::Reference(address)) => address,
             other => panic!("expected string reference, got {other:?}"),
         };

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -4,7 +4,7 @@ use crate::vm::error::VmError;
 use crate::vm::supervision::ExitSignal;
 use log;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Integer(i32),
     Float(f64),
@@ -29,7 +29,7 @@ pub enum MessageValue {
 #[allow(clippy::should_implement_trait)]
 impl Value {
     pub fn checked_add(self, other: Value) -> Result<Value, VmError> {
-        match (self, other) {
+        match (self.clone(), other.clone()) {
             (Value::Integer(a), Value::Integer(b)) => i32::checked_add(a, b)
                 .map(Value::Integer)
                 .ok_or(VmError::IntegerOverflow),
@@ -39,7 +39,7 @@ impl Value {
     }
 
     pub fn checked_sub(self, other: Value) -> Result<Value, VmError> {
-        match (self, other) {
+        match (self.clone(), other.clone()) {
             (Value::Integer(a), Value::Integer(b)) => i32::checked_sub(a, b)
                 .map(Value::Integer)
                 .ok_or(VmError::IntegerOverflow),
@@ -49,7 +49,7 @@ impl Value {
     }
 
     pub fn checked_mul(self, other: Value) -> Result<Value, VmError> {
-        match (self, other) {
+        match (self.clone(), other.clone()) {
             (Value::Integer(a), Value::Integer(b)) => i32::checked_mul(a, b)
                 .map(Value::Integer)
                 .ok_or(VmError::IntegerOverflow),
@@ -59,7 +59,7 @@ impl Value {
     }
 
     pub fn checked_div(self, other: Value) -> Result<Value, VmError> {
-        match (self, other) {
+        match (self.clone(), other.clone()) {
             (Value::Integer(a), Value::Integer(b)) => {
                 if b == 0 {
                     log::error!("Division by zero: {}/{}", a, b);

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -103,7 +103,7 @@ impl VM {
     }
 
     pub fn global(&self, name: &str) -> Option<Value> {
-        self.execution.globals().get(name).copied()
+        self.execution.globals().get(name).cloned()
     }
 
     pub fn heap_ref_count(&self, address: usize) -> Option<usize> {

--- a/tests/jump_if_false.rs
+++ b/tests/jump_if_false.rs
@@ -50,7 +50,7 @@ async fn jump_if_false_drops_reference_on_type_mismatch() {
 
     OpCode::SpawnActor(0).execute(&mut ctx, &mut heap).unwrap();
 
-    let address = match ctx.stack.last().copied() {
+    let address = match ctx.stack.last().cloned() {
         Some(Value::Reference(addr)) => addr,
         other => panic!("Expected actor reference on stack, got {other:?}"),
     };

--- a/tests/reference_counts.rs
+++ b/tests/reference_counts.rs
@@ -21,7 +21,7 @@ async fn actor_reference_lifecycle_on_stack() {
         .execute(&mut execution, &mut heap)
         .unwrap();
 
-    let address = match execution.stack.last().copied() {
+    let address = match execution.stack.last().cloned() {
         Some(Value::Reference(addr)) => addr,
         other => panic!("Expected actor reference on stack, got {other:?}"),
     };
@@ -51,7 +51,7 @@ async fn send_and_receive_message_updates_reference_counts() {
     OpCode::SpawnActor(0)
         .execute(&mut execution, &mut heap)
         .unwrap();
-    let actor_a = match execution.stack.last().copied() {
+    let actor_a = match execution.stack.last().cloned() {
         Some(Value::Reference(addr)) => addr,
         _ => panic!("Expected actor reference for target"),
     };
@@ -149,7 +149,7 @@ async fn neg_type_mismatch_consumes_reference_operand() {
         .execute(&mut execution, &mut heap)
         .unwrap();
 
-    let address = match execution.stack.last().copied() {
+    let address = match execution.stack.last().cloned() {
         Some(Value::Reference(addr)) => addr,
         other => panic!("Expected actor reference on stack, got {other:?}"),
     };
@@ -171,7 +171,7 @@ async fn add_and_mod_type_mismatch_do_not_leak_references() {
     OpCode::SpawnActor(0)
         .execute(&mut execution, &mut heap)
         .unwrap();
-    let add_ref = match execution.stack.last().copied() {
+    let add_ref = match execution.stack.last().cloned() {
         Some(Value::Reference(addr)) => addr,
         other => panic!("Expected actor reference on stack, got {other:?}"),
     };
@@ -188,7 +188,7 @@ async fn add_and_mod_type_mismatch_do_not_leak_references() {
     OpCode::SpawnActor(0)
         .execute(&mut execution, &mut heap)
         .unwrap();
-    let mod_ref = match execution.stack.last().copied() {
+    let mod_ref = match execution.stack.last().cloned() {
         Some(Value::Reference(addr)) => addr,
         other => panic!("Expected actor reference on stack, got {other:?}"),
     };

--- a/tests/supervision.rs
+++ b/tests/supervision.rs
@@ -70,7 +70,7 @@ async fn supervisor_restart_child_uses_one_for_all_strategy() {
     OpCode::SpawnSupervisor(0)
         .execute(&mut execution, &mut heap)
         .expect("spawn supervisor should succeed");
-    let supervisor_addr = match execution.stack.last().copied() {
+    let supervisor_addr = match execution.stack.last().cloned() {
         Some(Value::Reference(addr)) => addr,
         other => panic!("expected supervisor reference, got {other:?}"),
     };

--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -258,7 +258,7 @@ async fn spawn_send_and_receive_message_via_actor_handle() {
     OpCode::SpawnActor(0)
         .execute(&mut execution, &mut heap)
         .expect("spawn actor should succeed");
-    let actor_addr = match execution.stack.last().copied() {
+    let actor_addr = match execution.stack.last().cloned() {
         Some(Value::Reference(addr)) => addr,
         other => panic!("expected actor reference in stack, got {other:?}"),
     };
@@ -323,7 +323,7 @@ async fn native_io_print_is_available_from_standard_library() {
 
     vm.run().await.expect("native io.print should run");
 
-    assert_eq!(vm.stack().last().copied(), Some(Value::Null));
+    assert_eq!(vm.stack().last().cloned(), Some(Value::Null));
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation
- Move reference-count discipline from being by-convention (cheap implicit copies) to explicit cloning so ownership and refcount changes are visible at call sites. 
- Reduce accidental implicit duplication of heap references and make refcount updates easier to audit and reason about.

### Description
- Removed `Copy` from `Value` so `Value` is `Clone`-only and heap references are not implicitly duplicated (`src/vm/value.rs`).
- Updated arithmetic helpers to use `self.clone()`/`other.clone()` before pattern matching to preserve logging and avoid consuming operands (`checked_add`/`checked_sub`/`checked_mul`/`checked_div`).
- Changed reference retention semantics: added `retain_value(heap, &Value)` and adjusted callers to pass `&Value` and use explicit `clone()` when pushing/reusing values (`src/vm/opcodes.rs`, `src/vm/vm.rs`).
- Replaced `.copied()` call sites that required `Value: Copy` with `.cloned()` and added explicit `clone()` where necessary (runtime paths and tests).
- Updated heap traversal/serialization to clone nested `Value`s when converting to `MessageValue` (`src/vm/heap.rs`).
- Updated tests to use `.cloned()` and adjusted code paths to avoid ownership/move errors in non-`Copy` context (several test files under `tests/`).

### Testing
- Ran the full test suite with `cargo test -q`; all automated tests passed successfully (test suites executed and returned all green). 
- Test run produced only non-failing warnings (unused import / dead_code) which do not affect correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f64b776e8832883924f385bd77035)