### PR TITLE
Rename VM mailbox receive test to reflect blocking/timeout behavior

### DIFF
--- a/tests/vm_errors.rs
+++ b/tests/vm_errors.rs
@@ -289,14 +289,14 @@ async fn spawn_send_and_receive_message_via_actor_handle() {
 }
 
 #[tokio::test]
-async fn receive_message_on_closed_mailbox_returns_disconnected_error() {
+async fn receive_message_without_external_senders_times_out() {
     let code = vec![OpCode::ReceiveMessage];
     let (mut vm, tx) = VM::new(code, None);
     drop(tx);
     let result = tokio::time::timeout(std::time::Duration::from_millis(50), vm.run()).await;
     assert!(
         result.is_err(),
-        "VM retains an internal sender, so receive waits for a future message"
+        "VM retains an internal sender, so ReceiveMessage blocks waiting for a future message"
     );
 }
 


### PR DESCRIPTION
### Motivation
- The test named `receive_message_on_closed_mailbox_returns_disconnected_error` incorrectly implied it validated a disconnected mailbox path while the VM retains an internal sender so `ReceiveMessage` actually blocks waiting for a future message.

### Description
- Renamed the test function to `receive_message_without_external_senders_times_out` and updated the assertion message to state that `ReceiveMessage` blocks waiting for a future message.

### Testing
- Ran `cargo test --test vm_errors receive_message_without_external_senders_times_out` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f64bd69448328acb7cf5f15527061)