### PR TITLE
Use heap.release_reference in VM::pop_stack

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -80,12 +80,7 @@ impl VM {
         match self.execution.stack.pop() {
             Some(value) => {
                 if let Value::Reference(address) = value {
-                    if let Some(object) = self.heap.get_mut(address) {
-                        object.decrement_ref();
-                    } else {
-                        log::error!("Attempted to pop invalid heap reference: {}", address);
-                        return Err(VmError::InvalidReference);
-                    }
+                    self.heap.release_reference(address)?;
                 }
                 Ok(value)
             }


### PR DESCRIPTION
### Motivation
- Unify reference-release behavior so stack pops go through the heap's centralized release logic instead of calling `object.decrement_ref()` directly in this call site.

### Description
- Replace the inline `get_mut`/`decrement_ref` and manual invalid-reference handling in `VM::pop_stack` with a call to `self.heap.release_reference(address)?`.

### Testing
- Ran `cargo test -q vm_pop_stack_drops_actor_reference`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6d8bf258832897bc2fc2e06be11d)