### PR TITLE
Remove unused VM runtime reference-release helpers

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -43,31 +43,6 @@ fn increment_reference(heap: &mut Heap, address: usize) -> Result<(), VmError> {
     }
 }
 
-#[allow(dead_code)]
-fn decrement_reference(heap: &mut Heap, address: usize) -> Result<(), VmError> {
-    let child_references = if let Some(object) = heap.get_mut(address) {
-        let child_references = match object {
-            HeapObject::Array(elements, rc) if *rc == 1 => elements.clone(),
-            HeapObject::Module {
-                exports, ref_count, ..
-            } if *ref_count == 1 => exports.values().cloned().collect(),
-            _ => Vec::new(),
-        };
-        object.decrement_ref();
-        child_references
-    } else {
-        return Err(VmError::InvalidReference);
-    };
-
-    for value in child_references {
-        if let Value::Reference(child_address) = value {
-            heap.release_reference(child_address)?;
-        }
-    }
-
-    Ok(())
-}
-
 fn actor_start_ip(heap: &Heap, address: usize) -> Result<usize, VmError> {
     match heap.get(address) {
         Some(HeapObject::Actor(process, _, _)) => Ok(process.restart_ip()),

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -218,25 +218,10 @@ impl VM {
         Ok(())
     }
 
-    fn release_runtime_value(&mut self, value: Value) -> Result<(), VmError> {
-        if let Value::Reference(address) = value {
-            self.release_reference(address)?;
-        }
-        Ok(())
-    }
-
     fn increment_reference(&mut self, address: usize) -> Result<(), VmError> {
         if let Some(object) = self.heap.get_mut(address) {
             object.increment_ref();
             Ok(())
-        } else {
-            Err(VmError::InvalidReference)
-        }
-    }
-
-    fn release_reference(&mut self, address: usize) -> Result<(), VmError> {
-        if self.heap.get(address).is_some() {
-            self.heap.release_reference(address)
         } else {
             Err(VmError::InvalidReference)
         }


### PR DESCRIPTION
### Motivation
- Remove unreferenced helper functions and their partial/manual cascade logic so reference lifetime management remains centralized in the heap implementation and dead-code allowances are no longer needed.

### Description
- Deleted the unused `decrement_reference` function from `src/vm/opcodes.rs`, removing the `#[allow(dead_code)]` annotation and its ad-hoc cascade for `Array`/`Module` objects.
- Removed the unused `release_runtime_value` and `release_reference` helper methods from `src/vm/vm.rs` so runtime code relies on the `Heap` APIs for releasing references.
- Left `increment_reference` and `push_runtime_value` intact to preserve existing reference-increment behavior when values are pushed to the VM stack.

### Testing
- Ran the project test suite with `cargo test -q`; all automated tests completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6d94b7308328838ad7a155e134b3)