### PR TITLE
Release heap message reference on SendMessage Full path to avoid leak

### DIFF
--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -794,12 +794,13 @@ impl OpCode {
                             push_existing_value(execution, Value::Reference(address));
                             Ok(())
                         }
-                        Err(TrySendError::Full(message)) => {
+                        Err(TrySendError::Full(message_for_channel)) => {
+                            release_value(heap, message)?;
                             release_value(heap, actor_ref)?;
                             return Ok(ExecutionState::Yield(BlockingOperation::SendMessage {
                                 sender,
                                 actor_address: address,
-                                message,
+                                message: message_for_channel,
                             }));
                         }
                         Err(TrySendError::Closed(message_for_channel)) => {

--- a/tests/reference_counts.rs
+++ b/tests/reference_counts.rs
@@ -1,8 +1,10 @@
 use raft::vm::execution::ExecutionContext;
-use raft::vm::heap::{Heap, HeapObject};
+use raft::vm::heap::{Heap, HeapObject, ProcessHandle};
 use raft::vm::opcodes::OpCode;
 use raft::vm::value::{MessageValue, Value};
 use raft::vm::vm::VM;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
 use tokio::sync::mpsc::channel;
 
 fn actor_ref_count(heap: &Heap, address: usize) -> usize {
@@ -137,6 +139,54 @@ async fn vm_pop_stack_drops_actor_reference() {
         vm.heap_ref_count(actor_addr).is_none(),
         "actor should be collected after reference count reaches zero"
     );
+}
+
+#[tokio::test]
+async fn send_message_full_releases_reference_message_before_yield() {
+    let (_self_tx, mailbox) = channel(1);
+    let mut heap = Heap::new();
+    let mut execution = ExecutionContext::with_mailbox(vec![OpCode::Return], mailbox);
+
+    let (actor_sender, mut actor_mailbox) = mpsc::channel(1);
+    actor_sender
+        .send(MessageValue::Null)
+        .await
+        .expect("prefill actor mailbox to force TrySendError::Full");
+    let task = tokio::spawn(async { Ok(()) });
+    let final_stack = Arc::new(Mutex::new(Vec::new()));
+    let actor = ProcessHandle::new(
+        1,
+        None,
+        0,
+        vec![OpCode::Return],
+        None,
+        Vec::new(),
+        false,
+        task,
+        final_stack,
+    );
+    let actor_addr = heap.allocate(HeapObject::Actor(actor, actor_sender, 0));
+
+    let message_addr = heap.allocate(HeapObject::Array(vec![], 0));
+    OpCode::PushConst(Value::Reference(message_addr))
+        .execute(&mut execution, &mut heap)
+        .unwrap();
+    OpCode::PushConst(Value::Reference(actor_addr))
+        .execute(&mut execution, &mut heap)
+        .unwrap();
+
+    let state = OpCode::SendMessage.execute(&mut execution, &mut heap).unwrap();
+    assert!(
+        matches!(state, raft::vm::execution::ExecutionState::Yield(_)),
+        "expected SendMessage to yield when channel is full"
+    );
+
+    match heap.get(message_addr) {
+        Some(HeapObject::Array(_, rc)) => assert_eq!(*rc, 0, "message ref leaked on Full"),
+        other => panic!("expected message array, got {other:?}"),
+    }
+
+    let _ = actor_mailbox.recv().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent a reference-count leak when `OpCode::SendMessage` yields due to `TrySendError::Full` by ensuring the original runtime `message` value is released before yielding. 
- Preserve the channel-owned `MessageValue` (returned by Tokio) for retry semantics while avoiding double ownership of the originating heap object. 
- Add a regression test to make the leak visible and ensure the fix prevents it. 

### Description
- In `src/vm/opcodes.rs` release the popped runtime `message` with `release_value(heap, message)?` in the `TrySendError::Full` branch before returning `ExecutionState::Yield`, and yield the channel-owned `message_for_channel` instead. 
- Rename the `Full`-branch parameter to `message_for_channel` to distinguish the channel-owned message from the runtime `message`. 
- Add `send_message_full_releases_reference_message_before_yield` test in `tests/reference_counts.rs` which pre-fills an actor mailbox to force `TrySendError::Full`, runs `OpCode::SendMessage` with a reference-backed message, and asserts the heap refcount for the message is `0` after the yield. 
- Update test imports and setup (`ProcessHandle`, `Arc`, `Mutex`, `mpsc`) required to construct the controlled actor/mailbox scenario. 

### Testing
- Compiled the crate and ran the new regression test with `cargo test send_message_full_releases_reference_message_before_yield`, which passed. 
- The test verifies `OpCode::SendMessage` yields on a full channel and that the original message heap reference is not leaked (refcount is `0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6d838c848328a99538e05b786d54)