### PR TITLE
Remove no-op err value binding in send failure path

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -199,7 +199,6 @@ impl VM {
                 Ok(()) => self.push_runtime_value(Value::Reference(actor_address)),
                 Err(err) => {
                     let error = err.to_string();
-                    let _value = err.0;
                     self.push_runtime_value(Value::Reference(actor_address))?;
                     Err(VmError::ChannelSend {
                         error,


### PR DESCRIPTION
### Motivation
- The `SendMessage` error branch in `await_blocking_operation` bound `err.0` to `_value` but never used it, which is misleading and unnecessary since the `ChannelSend` event reports `Value::Null` anyway.

### Description
- Delete the unused `let _value = err.0;` line in `src/vm/vm.rs` inside the `BlockingOperation::SendMessage` `Err` arm so the behavior remains unchanged.

### Testing
- Ran `cargo test -q` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6dacf020832898224f0542f9bc5f)